### PR TITLE
Redesign repo list rows with activity sparklines

### DIFF
--- a/src/components/repos/RepoList.tsx
+++ b/src/components/repos/RepoList.tsx
@@ -24,11 +24,10 @@ export function RepoList({
       loading && repos !== null && 'opacity-40 pointer-events-none',
     )}>
       {/* Header strip */}
-      <div className="hidden md:grid grid-cols-[24px_minmax(0,5fr)_minmax(0,4fr)_90px_90px] gap-x-4 px-6 h-10 items-center border-b border-border bg-surface">
+      <div className="hidden md:grid grid-cols-[24px_minmax(0,1fr)_120px_100px] gap-x-4 px-6 h-10 items-center border-b border-border bg-surface">
         <span />
         <MicroLabel>repository</MicroLabel>
-        <MicroLabel>description</MicroLabel>
-        <MicroLabel>branch</MicroLabel>
+        <MicroLabel className="text-right">activity</MicroLabel>
         <MicroLabel className="text-right">updated</MicroLabel>
       </div>
 

--- a/src/components/repos/RepoRow.tsx
+++ b/src/components/repos/RepoRow.tsx
@@ -2,8 +2,10 @@ import { Link } from 'react-router-dom';
 import type { Repository } from '../../types/repo';
 import { shortDid } from '../../lib/api';
 import { usePrefetchRepo } from '../../hooks/usePrefetch';
+import { useRepoActivity } from '../../hooks/useRepoActivity';
 import { Pill } from '../ui/Pill';
 import { CopyButton } from '../ui/CopyButton';
+import { Sparkline } from './Sparkline';
 
 interface RepoRowProps {
   repo: Repository;
@@ -12,68 +14,68 @@ interface RepoRowProps {
 
 export function RepoRow({ repo, index }: RepoRowProps) {
   const prefetch = usePrefetchRepo(repo.owner, repo.name);
+  const { ref, activity } = useRepoActivity(repo.owner, repo.name);
 
   return (
     <li
+      ref={ref}
       {...prefetch}
-      className="group relative grid grid-cols-[16px_minmax(0,1fr)_auto] md:grid-cols-[24px_minmax(0,5fr)_minmax(0,4fr)_90px_90px]
-        items-start xl:items-center gap-x-3 md:gap-x-4 px-4 sm:px-6 py-4 xl:py-3
+      className="group relative grid grid-cols-[16px_minmax(0,1fr)_auto] md:grid-cols-[24px_minmax(0,1fr)_120px_100px]
+        items-start gap-x-3 md:gap-x-4 px-4 sm:px-6 py-4 md:py-5
         border-b border-border-inner last:border-b-0
         hover:bg-hover transition-colors animate-fade-up motion-reduce:animate-none"
       style={{ animationDelay: `${index * 16}ms` }}
     >
-      {/* Status dot */}
-      <span aria-hidden="true" className="pt-[3px] xl:pt-0 text-[8px] leading-none text-status-dot group-hover:text-warm transition-colors select-none">
+      {/* Status dot — aligned to the name line */}
+      <span aria-hidden="true" className="pt-[6px] text-[8px] leading-none text-status-dot group-hover:text-warm transition-colors select-none">
         ◆
       </span>
 
-      {/* Identity + pills — stacked normally, single line on xl */}
-      <div className="min-w-0 xl:flex xl:items-center xl:gap-3">
-        <Link
-          to={`/repos/${repo.owner}/${repo.name}`}
-          data-row-link
-          className="text-[14px] leading-snug outline-none min-w-0
-            after:absolute after:inset-0 after:content-['']
-            focus-visible:after:ring-1 focus-visible:after:ring-warm focus-visible:after:ring-inset"
-        >
-          <span className="text-dim">{shortDid(repo.owner)}/</span>
-          <span className="font-bold text-foreground break-all xl:break-normal">{repo.name}</span>
-        </Link>
+      {/* Line 1: identity + pills · Line 2: description */}
+      <div className="min-w-0">
+        <div className="flex items-center gap-x-3 gap-y-1.5 flex-wrap">
+          <Link
+            to={`/repos/${repo.owner}/${repo.name}`}
+            data-row-link
+            className="text-[14px] leading-snug outline-none min-w-0
+              after:absolute after:inset-0 after:content-['']
+              focus-visible:after:ring-1 focus-visible:after:ring-warm focus-visible:after:ring-inset"
+          >
+            <span className="text-dim">{shortDid(repo.owner)}/</span>
+            <span className="font-bold text-foreground break-all sm:break-normal">{repo.name}</span>
+          </Link>
 
-        {/* Description on mobile (own column on md+) */}
+          <div className="relative z-10 flex items-center gap-1.5 flex-wrap">
+            <Pill>{repo.branch}</Pill>
+            <Pill>{repo.visibility}</Pill>
+            <CopyButton value={`git clone ${repo.cloneUrl}`} label="clone" />
+            {repo.isMirror && (
+              <span className="text-[10px] uppercase tracking-[0.15em] text-dim pl-1">fork</span>
+            )}
+          </div>
+        </div>
+
         {repo.description && (
-          <p className="m-0 mt-1 text-[12px] text-muted-foreground line-clamp-2 md:hidden">
+          <p className="m-0 mt-1.5 text-[12.5px] leading-relaxed text-muted-foreground line-clamp-2 md:line-clamp-1">
             {repo.description}
           </p>
         )}
-
-        <div className="relative z-10 flex items-center gap-1.5 mt-2 xl:mt-0 flex-wrap xl:flex-nowrap xl:shrink-0">
-          <Pill>{repo.branch}</Pill>
-          <Pill>{repo.visibility}</Pill>
-          <CopyButton value={`git clone ${repo.cloneUrl}`} label="clone" />
-          {repo.stars > 0 && (
-            <span className="text-[11px] text-warm-text tabular-nums pl-1">★ {repo.stars}</span>
-          )}
-          {repo.isMirror && (
-            <span className="text-[10px] uppercase tracking-[0.15em] text-dim pl-1">fork</span>
-          )}
-        </div>
       </div>
 
-      {/* Description column (md+) */}
-      <p className="m-0 hidden md:block pt-[2px] xl:pt-0 text-[12.5px] leading-relaxed text-muted-foreground line-clamp-2 xl:line-clamp-1">
-        {repo.description}
-      </p>
+      {/* Activity sparkline (md+) */}
+      <div className="hidden md:flex justify-end self-center">
+        <Sparkline data={activity} />
+      </div>
 
-      {/* Branch column (md+) */}
-      <span className="hidden md:block pt-[2px] xl:pt-0 text-[12px] text-muted-foreground truncate">
-        {repo.branch}
-      </span>
-
-      {/* Updated */}
-      <span className="pt-[2px] xl:pt-0 text-[11px] md:text-[12px] tabular-nums text-dim text-right whitespace-nowrap">
-        {repo.updatedAt}
-      </span>
+      {/* Updated + stars */}
+      <div className="pt-[3px] text-right whitespace-nowrap">
+        <span className="block text-[11px] md:text-[12px] tabular-nums text-dim">
+          {repo.updatedAt}
+        </span>
+        {repo.stars > 0 && (
+          <span className="block mt-1 text-[11px] tabular-nums text-warm-text">★ {repo.stars}</span>
+        )}
+      </div>
     </li>
   );
 }

--- a/src/components/repos/RepoRowSkeleton.tsx
+++ b/src/components/repos/RepoRowSkeleton.tsx
@@ -2,20 +2,21 @@ import { Skeleton } from '../ui/Skeleton';
 
 export function RepoRowSkeleton() {
   return (
-    <li className="grid grid-cols-[16px_minmax(0,1fr)_auto] md:grid-cols-[24px_minmax(0,5fr)_minmax(0,4fr)_90px_90px]
-      items-start gap-x-3 md:gap-x-4 px-4 sm:px-6 py-4 border-b border-border-inner last:border-b-0">
+    <li className="grid grid-cols-[16px_minmax(0,1fr)_auto] md:grid-cols-[24px_minmax(0,1fr)_120px_100px]
+      items-start gap-x-3 md:gap-x-4 px-4 sm:px-6 py-4 md:py-5 border-b border-border-inner last:border-b-0">
       <span />
       <div>
-        <Skeleton className="h-4 w-48 max-w-full" />
-        <div className="flex gap-1.5 mt-2.5">
-          <Skeleton className="h-7 w-14" />
-          <Skeleton className="h-7 w-16" />
-          <Skeleton className="h-7 w-16" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-4 w-48 max-w-full" />
+          <Skeleton className="hidden sm:block h-7 w-14" />
+          <Skeleton className="hidden sm:block h-7 w-16" />
         </div>
+        <Skeleton className="h-3.5 w-3/4 max-w-96 mt-2" />
       </div>
-      <Skeleton className="hidden md:block h-4 w-3/4 mt-[2px]" />
-      <Skeleton className="hidden md:block h-4 w-12 mt-[2px]" />
-      <Skeleton className="h-4 w-14 mt-[2px] justify-self-end" />
+      <div className="hidden md:flex justify-end self-center">
+        <Skeleton className="h-[28px] w-[110px]" />
+      </div>
+      <Skeleton className="h-4 w-14 mt-[3px] justify-self-end" />
     </li>
   );
 }

--- a/src/components/repos/Sparkline.tsx
+++ b/src/components/repos/Sparkline.tsx
@@ -1,0 +1,69 @@
+// Micro bar chart of weekly commit counts (oldest → newest). Single series:
+// past weeks in a de-emphasis tone, the current week in the warm accent.
+// Decorative at this size — the value lives in the aria-label.
+
+interface SparklineProps {
+  /** Weekly counts, oldest → newest. null = loading, [] = unavailable. */
+  data: number[] | null;
+}
+
+const W = 110;
+const H = 28;
+const GAP = 2;
+const TOP_PAD = 3;
+const BASELINE_Y = H - 1;
+
+export function Sparkline({ data }: SparklineProps) {
+  const loading = data === null;
+  const empty = !loading && (data.length === 0 || data.every(v => v === 0));
+  const total = data?.reduce((a, b) => a + b, 0) ?? 0;
+  const max = data && data.length > 0 ? Math.max(...data) : 0;
+  const slot = data && data.length > 0 ? W / data.length : 0;
+
+  // The node returns at most 30 commits; a sum that reaches the cap means the
+  // window's true count was truncated, so report it as a floor.
+  const countLabel = total >= 30 ? `${total}+ commits` : `${total} commit${total === 1 ? '' : 's'}`;
+  const label = loading
+    ? undefined
+    : empty
+      ? 'no recent commits'
+      : `${countLabel} in the last ${data.length} weeks`;
+
+  return (
+    <svg
+      width={W}
+      height={H}
+      viewBox={`0 0 ${W} ${H}`}
+      role={label ? 'img' : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+      className="shrink-0"
+    >
+      <line
+        x1={0}
+        y1={BASELINE_Y + 0.5}
+        x2={W}
+        y2={BASELINE_Y + 0.5}
+        stroke="var(--color-border)"
+        strokeWidth={1}
+      />
+      {!loading &&
+        data.map((count, i) => {
+          if (count === 0) return null;
+          const h = Math.max(2, Math.round((count / max) * (H - TOP_PAD - 1)));
+          const current = i === data.length - 1;
+          return (
+            <rect
+              key={i}
+              x={i * slot + GAP / 2}
+              y={BASELINE_Y - h}
+              width={slot - GAP}
+              height={h}
+              rx={1}
+              fill={current ? 'var(--color-warm)' : 'var(--color-text-faint)'}
+            />
+          );
+        })}
+    </svg>
+  );
+}

--- a/src/hooks/useRepoActivity.ts
+++ b/src/hooks/useRepoActivity.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+import { getCachedActivity, loadActivity } from '../lib/activity';
+
+/**
+ * Lazy weekly-activity buckets for a repo row. Attach `ref` to the row
+ * element — the fetch only starts once the row scrolls near the viewport,
+ * so paging through the list doesn't hammer the node.
+ * `activity` is null while loading, [] when unavailable.
+ */
+export function useRepoActivity(owner: string, name: string) {
+  const ref = useRef<HTMLLIElement>(null);
+  const [activity, setActivity] = useState<number[] | null>(
+    () => getCachedActivity(owner, name) ?? null,
+  );
+
+  useEffect(() => {
+    if (getCachedActivity(owner, name)) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    let cancelled = false;
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries.some(e => e.isIntersecting)) return;
+        observer.disconnect();
+        void loadActivity(owner, name).then(buckets => {
+          if (!cancelled) setActivity(buckets);
+        });
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(el);
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [owner, name]);
+
+  return { ref, activity };
+}

--- a/src/lib/activity.test.ts
+++ b/src/lib/activity.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { bucketCommitDates, ACTIVITY_WEEKS } from './activity';
+
+const NOW = new Date('2026-07-01T12:00:00Z').getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+function daysAgo(n: number): string {
+  return new Date(NOW - n * DAY).toISOString();
+}
+
+describe('bucketCommitDates', () => {
+  it('returns all-zero buckets for no commits', () => {
+    const buckets = bucketCommitDates([], NOW);
+    expect(buckets).toHaveLength(ACTIVITY_WEEKS);
+    expect(buckets.every(b => b === 0)).toBe(true);
+  });
+
+  it('puts a commit from today in the newest bucket', () => {
+    const buckets = bucketCommitDates([daysAgo(0)], NOW);
+    expect(buckets[ACTIVITY_WEEKS - 1]).toBe(1);
+    expect(buckets.reduce((a, b) => a + b, 0)).toBe(1);
+  });
+
+  it('puts a commit from 6 days ago in the newest bucket too', () => {
+    const buckets = bucketCommitDates([daysAgo(6)], NOW);
+    expect(buckets[ACTIVITY_WEEKS - 1]).toBe(1);
+  });
+
+  it('puts a commit from 8 days ago in the second-newest bucket', () => {
+    const buckets = bucketCommitDates([daysAgo(8)], NOW);
+    expect(buckets[ACTIVITY_WEEKS - 2]).toBe(1);
+  });
+
+  it('drops commits older than the window', () => {
+    const buckets = bucketCommitDates([daysAgo(ACTIVITY_WEEKS * 7 + 1)], NOW);
+    expect(buckets.reduce((a, b) => a + b, 0)).toBe(0);
+  });
+
+  it('counts future-dated commits (clock skew) as this week', () => {
+    const buckets = bucketCommitDates([new Date(NOW + DAY).toISOString()], NOW);
+    expect(buckets[ACTIVITY_WEEKS - 1]).toBe(1);
+  });
+
+  it('ignores unparseable dates', () => {
+    const buckets = bucketCommitDates(['not-a-date', daysAgo(1)], NOW);
+    expect(buckets.reduce((a, b) => a + b, 0)).toBe(1);
+  });
+
+  it('accumulates multiple commits in the same week', () => {
+    const buckets = bucketCommitDates([daysAgo(0), daysAgo(1), daysAgo(2)], NOW);
+    expect(buckets[ACTIVITY_WEEKS - 1]).toBe(3);
+  });
+});

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,87 @@
+import { fetchCommits } from './api';
+import { getCachedRepo, repoCacheKey } from './repoCache';
+
+// Weekly commit-activity buckets for the repo list sparklines.
+// The node's /commits endpoint returns at most the 30 most recent commits,
+// so this is a "recent activity" window, not full history.
+
+export const ACTIVITY_WEEKS = 12;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Bucket ISO commit dates into weekly counts, oldest → newest. */
+export function bucketCommitDates(
+  dates: string[],
+  now: number,
+  weeks: number = ACTIVITY_WEEKS,
+): number[] {
+  const buckets = new Array<number>(weeks).fill(0);
+  for (const iso of dates) {
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) continue;
+    // Future dates (clock skew between node and client) count as this week.
+    const age = Math.max(0, now - t);
+    const idx = weeks - 1 - Math.floor(age / WEEK_MS);
+    if (idx >= 0) buckets[idx]++;
+  }
+  return buckets;
+}
+
+const cache = new Map<string, number[]>();
+const inflight = new Map<string, Promise<number[]>>();
+
+// The node limits concurrent connections (see repoCache.ts), so list-page
+// activity fetches funnel through a small slot pool instead of firing one
+// request per visible row at once.
+const MAX_CONCURRENT = 2;
+let active = 0;
+const waiting: Array<() => void> = [];
+
+async function withSlot<T>(job: () => Promise<T>): Promise<T> {
+  if (active >= MAX_CONCURRENT) {
+    await new Promise<void>(resolve => waiting.push(resolve));
+  }
+  active++;
+  try {
+    return await job();
+  } finally {
+    active--;
+    waiting.shift()?.();
+  }
+}
+
+export function getCachedActivity(owner: string, name: string): number[] | undefined {
+  return cache.get(repoCacheKey(owner, name));
+}
+
+/**
+ * Load weekly activity buckets for a repo. Deduped per repo and cached for
+ * the session; a hover-prefetched repo (repoCache) resolves without a fetch.
+ * Errors resolve to an empty array — the sparkline is decorative, so a repo
+ * whose commits can't load renders as "no data" rather than retrying.
+ */
+export function loadActivity(owner: string, name: string): Promise<number[]> {
+  const key = repoCacheKey(owner, name);
+  const hit = cache.get(key);
+  if (hit) return Promise.resolve(hit);
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const promise = (async () => {
+    const prefetched = getCachedRepo(key);
+    const dates = prefetched
+      ? prefetched.commits.flatMap(c => (c.dateRaw ? [c.dateRaw] : []))
+      : (await withSlot(() => fetchCommits(owner, name))).map(c => c.date);
+    return bucketCommitDates(dates, Date.now());
+  })()
+    .catch(() => [] as number[])
+    .then(buckets => {
+      cache.set(key, buckets);
+      return buckets;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, promise);
+  return promise;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -363,6 +363,7 @@ export function mapApiRepo(
     message: c.message,
     time: timeAgo(c.date),
     author: c.author,
+    dateRaw: c.date,
   }));
 
   return {

--- a/src/types/repo.ts
+++ b/src/types/repo.ts
@@ -10,6 +10,8 @@ export interface RepoCommit {
   message: string;
   time: string;
   author?: string;
+  /** ISO timestamp kept for activity bucketing */
+  dateRaw?: string;
 }
 
 export interface Repository {


### PR DESCRIPTION
# Description

Redesigns the repository list rows and adds a GitHub-style commit-activity graph.

Rows go from a dense single line (~44px) to a taller two-line layout (~95px):
repo name + pills on line one, full-width description on line two, updated time
and stars stacked in a right-aligned meta column. The squeezed description/branch
grid columns are removed (branch was already shown as a pill).

Each row gains an **activity sparkline** (md+ viewports): a dependency-free
110×28 SVG bar chart of weekly commit counts over the last 12 weeks — past weeks
in a de-emphasis tone, the current week in the warm accent. The value is exposed
via `aria-label`; sums at the node's 30-commit API cap read as a floor ("30+ commits").

Loading is node-friendly: `useRepoActivity` fetches `/commits` only once a row
scrolls near the viewport (IntersectionObserver, 200px margin), through a 2-slot
concurrency pool (the node limits concurrent connections), with a session cache.
Hover-prefetched repos (`repoCache`) resolve without any fetch via the new
`RepoCommit.dateRaw` field.

Known limitation: the node returns at most 30 commits, so hyperactive repos
collapse into a single current-week bar. The real fix is server-side weekly
buckets on the list endpoint — a good candidate to bundle with the pending
`q=`/`sort=` node deploy.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / code quality (no behavior change)
- [ ] Documentation
- [ ] Tests / CI

## How was this tested?

- 8 new unit tests for the week-bucketing logic (`src/lib/activity.test.ts`);
  full suite: 68 tests passing.
- Driven end-to-end with Playwright against the live node (dev proxy):
  - Max in-flight `/commits` requests observed: **2** (concurrency cap holds).
  - Only near-viewport rows fetch: 6 requests on load, 12 more after paging to
    page 2 — not one per row.
  - Sparklines hidden below `md` (0 visible at 390px); rows stack cleanly on mobile.
  - Verified light and dark themes via the app's own `theme` persistence.
  - Zero console errors.

## Screenshots
<img width="1299" height="639" alt="Screenshot 2026-07-03 at 8 26 02 AM" src="https://github.com/user-attachments/assets/da2fb08a-d162-423c-b833-e1800b4d17e8" />


## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes (includes typecheck)
- [x] New logic in `src/lib/` has colocated unit tests
- [x] I kept the change focused on a single concern