### PR TITLE
Add Vercel rewrites for API proxy and SPA fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "https://node.gitlawb.com/api/:path*" },
+    { "source": "/node-info", "destination": "https://node.gitlawb.com/" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
# Description

Production deploys on Vercel 404'd every API call ("failed to load repositories:
Failed to fetch repos: 404"). The app fetches `/api/v1/repos` same-origin, but the
proxy that forwards `/api` and `/node-info` to `node.gitlawb.com` lives in Vite's
dev server only — the deployed static build had nothing behind those paths.

`vercel.json` now mirrors the dev proxy in production:

- `/api/*` → `https://node.gitlawb.com/api/*`
- `/node-info` → `https://node.gitlawb.com/` (node identity lives at the node's root)
- catch-all → `/index.html` (SPA fallback so client-side routes like
  `/repos/:owner/:name` survive refresh and deep links — static assets are
  unaffected since Vercel serves filesystem matches before rewrites)

Also adds `.vercel/` (the CLI's project-link directory) to `.gitignore`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / code quality (no behavior change)
- [ ] Documentation
- [ ] Tests / CI

## How was this tested?

- Preview deploy with this config: repo list, node info, and deep links verified
  working in the browser (preview URLs are SSO-protected, so verification was
  interactive rather than curl).
- Promoted to production (`vercel --prod`), deployment READY and aliased to
  explorer.gitlawb.com.
- `npm run lint` / `npm test` (72) / `npm run build` all pass — config-only
  change, no source touched.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes (includes typecheck)
- [x] New logic in `src/lib/` has colocated unit tests
- [x] I kept the change focused on a single concern