### PR TITLE
Add node home, peers, events, tasks, and network sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,31 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import AppLayout from './components/layout/AppLayout';
+import HomePage from './pages/HomePage';
 import RepositoriesPage from './pages/RepositoriesPage';
 import RepositoryDetailPage from './pages/RepositoryDetailPage';
 import AgentsPage from './pages/AgentsPage';
+import PeersPage from './pages/PeersPage';
+import EventsPage from './pages/EventsPage';
+import TasksPage from './pages/TasksPage';
+import TaskDetailPage from './pages/TaskDetailPage';
+import NetworkPage from './pages/NetworkPage';
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Navigate to="/repos" replace />} />
         <Route element={<AppLayout />}>
+          <Route path="/" element={<HomePage />} />
           <Route path="/repos" element={<RepositoriesPage />} />
           <Route path="/agents" element={<AgentsPage />} />
           <Route path="/repos/:owner/:name" element={<RepositoryDetailPage />} />
+          <Route path="/peers" element={<PeersPage />} />
+          <Route path="/events" element={<EventsPage />} />
+          <Route path="/tasks" element={<TasksPage />} />
+          <Route path="/tasks/:id" element={<TaskDetailPage />} />
+          <Route path="/network" element={<NetworkPage />} />
         </Route>
-        <Route path="*" element={<Navigate to="/repos" replace />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/events/RefUpdateList.tsx
+++ b/src/components/events/RefUpdateList.tsx
@@ -1,0 +1,123 @@
+import { Link } from 'react-router-dom';
+import { cn } from '../../lib/utils';
+import type { ApiRefUpdate } from '../../lib/api';
+import { parseEventRepo, shortRefName, shortSha, shortDid, timeAgo, isGossip } from '../../lib/api';
+import { MicroLabel } from '../ui/MicroLabel';
+import { Skeleton } from '../ui/Skeleton';
+
+function RefUpdateRow({ event, index }: { event: ApiRefUpdate; index: number }) {
+  const repoRef = parseEventRepo(event.repo);
+  const gossip = isGossip(event);
+  const created = event.old_sha?.startsWith('0000000');
+
+  return (
+    <li
+      className="grid grid-cols-[16px_minmax(0,1fr)_80px] md:grid-cols-[24px_minmax(0,1fr)_150px_120px_90px]
+        items-baseline gap-x-3 md:gap-x-4 px-4 sm:px-6 py-3
+        border-b border-border-inner last:border-b-0 hover:bg-hover transition-colors
+        animate-fade-up motion-reduce:animate-none"
+      style={{ animationDelay: `${index * 16}ms` }}
+    >
+      <span
+        aria-hidden="true"
+        className={cn('text-[8px] leading-none select-none self-start pt-[5px]', gossip ? 'text-warm' : 'text-status-dot')}
+        title={gossip ? 'received via gossip' : 'local push'}
+      >
+        ◆
+      </span>
+
+      {/* repo / ref */}
+      <span className="min-w-0 truncate text-[13px]">
+        {repoRef ? (
+          <Link
+            to={`/repos/${encodeURIComponent(repoRef.ownerDid)}/${encodeURIComponent(repoRef.name)}`}
+            className="font-bold text-foreground hover:text-warm-text transition-colors"
+          >
+            {repoRef.label}
+          </Link>
+        ) : (
+          <span className="font-bold text-foreground">{event.repo}</span>
+        )}
+        <span className="text-dim"> · {shortRefName(event.ref_name)}</span>
+      </span>
+
+      {/* sha transition */}
+      <span className="hidden md:block text-[12px] text-muted-foreground tabular-nums whitespace-nowrap">
+        {created ? (
+          <>new · {shortSha(event.new_sha)}</>
+        ) : (
+          <>{shortSha(event.old_sha)} → {shortSha(event.new_sha)}</>
+        )}
+      </span>
+
+      {/* pusher */}
+      <span className="hidden md:block text-[12px] text-dim truncate" title={event.pusher_did}>
+        {shortDid(event.pusher_did)}
+      </span>
+
+      {/* time */}
+      <span className="text-[11px] text-dim tabular-nums text-right whitespace-nowrap">
+        {timeAgo(event.timestamp)}
+      </span>
+    </li>
+  );
+}
+
+function RefUpdateRowSkeleton() {
+  return (
+    <li className="grid grid-cols-[16px_minmax(0,1fr)_80px] md:grid-cols-[24px_minmax(0,1fr)_150px_120px_90px]
+      items-center gap-x-3 md:gap-x-4 px-4 sm:px-6 py-3 border-b border-border-inner last:border-b-0">
+      <span />
+      <Skeleton className="h-4 w-52 max-w-full" />
+      <Skeleton className="hidden md:block h-4 w-28" />
+      <Skeleton className="hidden md:block h-4 w-20" />
+      <Skeleton className="h-3 w-14 justify-self-end" />
+    </li>
+  );
+}
+
+interface RefUpdateListProps {
+  events: ApiRefUpdate[] | null;
+  loading?: boolean;
+  skeletonCount?: number;
+  /** Hide the md+ header strip (compact embeds, e.g. the dashboard). */
+  header?: boolean;
+  emptyMessage?: string;
+}
+
+export function RefUpdateList({
+  events,
+  loading = false,
+  skeletonCount = 10,
+  header = true,
+  emptyMessage = 'no ref updates yet — push a repo to this node to see activity',
+}: RefUpdateListProps) {
+  return (
+    <div className={cn(
+      'transition-opacity duration-200',
+      loading && events !== null && 'opacity-40 pointer-events-none',
+    )}>
+      {header && (
+        <div className="hidden md:grid grid-cols-[24px_minmax(0,1fr)_150px_120px_90px] gap-x-4 px-6 h-10 items-center border-b border-border bg-surface">
+          <span />
+          <MicroLabel>repo · ref</MicroLabel>
+          <MicroLabel>commit</MicroLabel>
+          <MicroLabel>pusher</MicroLabel>
+          <MicroLabel className="text-right">when</MicroLabel>
+        </div>
+      )}
+
+      {events === null ? (
+        <ul className="m-0 p-0 list-none" aria-busy="true" aria-label="loading events">
+          {Array.from({ length: skeletonCount }, (_, i) => <RefUpdateRowSkeleton key={i} />)}
+        </ul>
+      ) : events.length === 0 ? (
+        <p className="m-0 py-16 text-center text-[13px] text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="m-0 p-0 list-none">
+          {events.map((event, i) => <RefUpdateRow key={event.id} event={event} index={i} />)}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import TopBar from './TopBar';
 import Footer from './Footer';
+import { ExploreTabs } from './ExploreTabs';
 import { ShortcutsProvider } from '../keyboard/ShortcutsProvider';
 
 export default function AppLayout() {
@@ -8,6 +9,9 @@ export default function AppLayout() {
     <ShortcutsProvider>
       <div className="flex min-h-screen flex-col bg-background text-foreground">
         <TopBar />
+        <div className="max-w-[1280px] w-full mx-auto px-4 sm:px-8 lg:px-12">
+          <ExploreTabs />
+        </div>
         <main className="flex-1">
           <Outlet />
         </main>

--- a/src/components/layout/ExploreTabs.tsx
+++ b/src/components/layout/ExploreTabs.tsx
@@ -3,18 +3,34 @@ import { cn } from '../../lib/utils';
 
 const tabCls = ({ isActive }: { isActive: boolean }) =>
   cn(
-    'inline-flex items-center h-10 px-1 text-[13px] lowercase border-b-2 -mb-px transition-colors',
+    'inline-flex items-center h-10 px-1 text-[13px] lowercase border-b-2 -mb-px transition-colors shrink-0',
     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warm',
     isActive
       ? 'border-warm text-foreground font-bold'
       : 'border-transparent text-muted-foreground hover:text-foreground',
   );
 
+const SECTIONS = [
+  { to: '/', label: 'overview', end: true },
+  { to: '/repos', label: 'repositories' },
+  { to: '/agents', label: 'agents' },
+  { to: '/peers', label: 'peers' },
+  { to: '/events', label: 'events' },
+  { to: '/tasks', label: 'tasks' },
+  { to: '/network', label: 'network' },
+] as const;
+
 export function ExploreTabs() {
   return (
-    <nav aria-label="explore" className="flex gap-6 border-b border-border pt-4">
-      <NavLink to="/repos" className={tabCls}>repositories</NavLink>
-      <NavLink to="/agents" className={tabCls}>agents</NavLink>
+    <nav
+      aria-label="explore"
+      className="flex gap-5 sm:gap-6 border-b border-border pt-4 overflow-x-auto scrollbar-none"
+    >
+      {SECTIONS.map(s => (
+        <NavLink key={s.to} to={s.to} end={'end' in s && s.end} className={tabCls}>
+          {s.label}
+        </NavLink>
+      ))}
     </nav>
   );
 }

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -13,7 +13,7 @@ export default function TopBar() {
 
         {/* Left: branding */}
         <Link
-          to="/repos"
+          to="/"
           className="flex items-center gap-2.5 shrink-0 min-w-0
             focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warm"
         >

--- a/src/components/network/NodeCard.tsx
+++ b/src/components/network/NodeCard.tsx
@@ -1,0 +1,88 @@
+import { cn } from '../../lib/utils';
+import type { NodeSnapshot } from '../../lib/nodes';
+import { truncateDid } from '../../lib/api';
+import { MicroLabel } from '../ui/MicroLabel';
+import { CopyButton } from '../ui/CopyButton';
+import { Skeleton } from '../ui/Skeleton';
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="px-3 py-2.5 text-center">
+      <p className="m-0 text-[16px] font-bold tabular-nums leading-none text-foreground">{value}</p>
+      <MicroLabel className="block mt-1.5 !text-[9px]">{label}</MicroLabel>
+    </div>
+  );
+}
+
+export function NodeCardSkeleton() {
+  return (
+    <div className="border border-border">
+      <div className="flex items-center gap-2 px-4 h-10 border-b border-border bg-surface">
+        <Skeleton className="h-3 w-32" />
+      </div>
+      <div className="px-4 py-4 flex flex-col gap-2.5">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    </div>
+  );
+}
+
+export function NodeCard({ snapshot }: { snapshot: NodeSnapshot }) {
+  const { node, reachable, info, stats, peers, p2p } = snapshot;
+
+  return (
+    <div className={cn('border border-border flex flex-col', !reachable && 'opacity-60')}>
+      <div className="flex items-center justify-between gap-2 px-4 h-10 border-b border-border bg-surface min-w-0">
+        <span className="flex items-center gap-2 min-w-0">
+          <span
+            aria-hidden="true"
+            className={cn('text-[8px] shrink-0', reachable ? 'text-ok' : 'text-destructive')}
+            title={reachable ? 'online' : 'offline'}
+          >
+            ◆
+          </span>
+          <a
+            href={node.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] font-bold text-foreground truncate hover:text-warm-text transition-colors"
+          >
+            {node.label} ↗
+          </a>
+        </span>
+        {info?.version && <span className="text-[10px] text-dim shrink-0">v{info.version}</span>}
+      </div>
+
+      <div className="px-4 py-3 flex flex-col gap-2 flex-1">
+        {info?.did ? (
+          <span className="flex items-center gap-2 min-w-0">
+            <span className="text-[11px] text-muted-foreground truncate" title={info.did}>
+              {truncateDid(info.did)}
+            </span>
+            <CopyButton value={info.did} label="did" />
+          </span>
+        ) : (
+          <span className="text-[11px] text-dim">{reachable ? 'identity unavailable' : 'node unreachable'}</span>
+        )}
+
+        {p2p?.enabled && (
+          <span className="text-[10px] text-dim tabular-nums">
+            libp2p · {p2p.connected_peers ?? 0} connected · {peers?.length ?? 0} known peers
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 border-t border-border-inner">
+        <Metric label="repos" value={stats ? stats.repos.toLocaleString() : '—'} />
+        <div className="border-l border-border-inner">
+          <Metric label="agents" value={stats ? stats.agents.toLocaleString() : '—'} />
+        </div>
+        <div className="border-l border-border-inner">
+          <Metric label="pushes" value={stats ? stats.pushes.toLocaleString() : '—'} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/network/ReplicationTable.tsx
+++ b/src/components/network/ReplicationTable.tsx
@@ -1,0 +1,111 @@
+import { cn } from '../../lib/utils';
+import type { ReplicationStatus, Presence } from '../../lib/replication';
+import { parseEventRepo, shortRefName, shortSha, timeAgo } from '../../lib/api';
+import { MicroLabel } from '../ui/MicroLabel';
+
+const PRESENCE_GLYPH: Record<Presence, { glyph: string; cls: string; title: string }> = {
+  origin: { glyph: '◆', cls: 'text-warm', title: 'origin — received the push' },
+  replicated: { glyph: '◆', cls: 'text-ok', title: 'replicated via gossip' },
+  missing: { glyph: '◇', cls: 'text-dim', title: 'not yet replicated' },
+};
+
+interface ReplicationTableProps {
+  replication: ReplicationStatus;
+  /** Node labels in display order (columns). */
+  labels: string[];
+  rowLimit?: number;
+}
+
+export function ReplicationTable({ replication, labels, rowLimit = 12 }: ReplicationTableProps) {
+  const rows = replication.rows.slice(0, rowLimit);
+  const short = (label: string) => label.split('.')[0];
+
+  return (
+    <div className="border border-border">
+      <div className="flex items-center justify-between gap-3 px-4 sm:px-6 h-10 border-b border-border bg-surface">
+        <MicroLabel>replication — latest ref updates across nodes</MicroLabel>
+        <span className="text-[11px] tabular-nums text-muted-foreground">
+          {replication.fullyReplicatedCount}/{replication.totalTuples} in sync ·{' '}
+          <span className={replication.coveragePercent >= 90 ? 'text-ok' : 'text-warm-text'}>
+            {replication.coveragePercent}%
+          </span>
+        </span>
+      </div>
+
+      <div className="overflow-x-auto">
+        <div className="min-w-[640px]">
+          {/* Header */}
+          <div
+            className="grid gap-x-4 px-4 sm:px-6 h-10 items-center border-b border-border bg-surface"
+            style={{ gridTemplateColumns: `minmax(0,1fr) 90px 70px repeat(${labels.length}, 88px)` }}
+          >
+            <MicroLabel>repo · ref</MicroLabel>
+            <MicroLabel>commit</MicroLabel>
+            <MicroLabel>when</MicroLabel>
+            {labels.map(l => (
+              <MicroLabel key={l} className="text-center">{short(l)}</MicroLabel>
+            ))}
+          </div>
+
+          {rows.length === 0 ? (
+            <p className="m-0 py-12 text-center text-[13px] text-muted-foreground">
+              no ref updates observed on any node yet
+            </p>
+          ) : (
+            <ul className="m-0 p-0 list-none">
+              {rows.map(row => {
+                const repoRef = parseEventRepo(row.tuple.repo);
+                return (
+                  <li
+                    key={row.tuple.key}
+                    className="grid gap-x-4 px-4 sm:px-6 py-2.5 items-baseline border-b border-border-inner last:border-b-0 hover:bg-hover transition-colors"
+                    style={{ gridTemplateColumns: `minmax(0,1fr) 90px 70px repeat(${labels.length}, 88px)` }}
+                  >
+                    <span className="min-w-0 truncate text-[12px]">
+                      <span className="font-bold text-foreground">
+                        {repoRef ? repoRef.label : row.tuple.repo}
+                      </span>
+                      <span className="text-dim"> · {shortRefName(row.tuple.ref_name)}</span>
+                    </span>
+                    <span className="text-[11px] text-muted-foreground tabular-nums">
+                      {shortSha(row.tuple.new_sha)}
+                    </span>
+                    <span className="text-[11px] text-dim tabular-nums whitespace-nowrap">
+                      {timeAgo(row.tuple.timestamp)}
+                    </span>
+                    {labels.map(label => {
+                      const presence = row.presence[label] ?? 'missing';
+                      const { glyph, cls, title } = PRESENCE_GLYPH[presence];
+                      return (
+                        <span
+                          key={label}
+                          className={cn('text-center text-[10px] select-none', cls)}
+                          title={`${label}: ${title}`}
+                        >
+                          {glyph}
+                        </span>
+                      );
+                    })}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Legend + drift */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 px-4 sm:px-6 py-3 border-t border-border text-[10px] text-dim">
+        <span><span aria-hidden="true" className="text-warm">◆</span> origin</span>
+        <span><span aria-hidden="true" className="text-ok">◆</span> replicated</span>
+        <span><span aria-hidden="true">◇</span> missing</span>
+        <span className="flex-1" />
+        {labels.map(l => (
+          <span key={l} className="tabular-nums">
+            {short(l)}: {replication.driftByNode[l] ?? 0} behind
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/peers/PeerList.tsx
+++ b/src/components/peers/PeerList.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+import { cn } from '../../lib/utils';
+import type { ApiPeer } from '../../lib/api';
+import { pingPeer, peerHost, shortDid, timeAgo } from '../../lib/api';
+import { MicroLabel } from '../ui/MicroLabel';
+import { Skeleton } from '../ui/Skeleton';
+import { Pill } from '../ui/Pill';
+import { CopyButton } from '../ui/CopyButton';
+
+type PingState =
+  | { kind: 'idle' }
+  | { kind: 'pinging' }
+  | { kind: 'done'; ok: boolean; ms: number };
+
+function PingCell({ did }: { did: string }) {
+  const [state, setState] = useState<PingState>({ kind: 'idle' });
+
+  const ping = async () => {
+    setState({ kind: 'pinging' });
+    const started = performance.now();
+    try {
+      const ok = await pingPeer(did);
+      setState({ kind: 'done', ok, ms: Math.round(performance.now() - started) });
+    } catch {
+      setState({ kind: 'done', ok: false, ms: Math.round(performance.now() - started) });
+    }
+  };
+
+  if (state.kind === 'done') {
+    return (
+      <button
+        type="button"
+        onClick={ping}
+        title="ping again"
+        className={cn(
+          'text-[11px] tabular-nums cursor-pointer bg-transparent border-0 p-0 text-right',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warm',
+          state.ok ? 'text-ok' : 'text-destructive',
+        )}
+      >
+        {state.ok ? `${state.ms}ms ✓` : 'no reply'}
+      </button>
+    );
+  }
+  return (
+    <Pill onClick={ping} disabled={state.kind === 'pinging'} aria-label={`ping peer ${shortDid(did)}`}>
+      {state.kind === 'pinging' ? 'pinging…' : 'ping'}
+    </Pill>
+  );
+}
+
+function PeerRow({ peer, index }: { peer: ApiPeer; index: number }) {
+  return (
+    <li
+      className="grid grid-cols-[16px_minmax(0,1fr)_70px] md:grid-cols-[24px_minmax(0,4fr)_minmax(0,3fr)_120px_90px]
+        items-center gap-x-3 md:gap-x-4 px-4 sm:px-6 py-3
+        border-b border-border-inner last:border-b-0 hover:bg-hover transition-colors
+        animate-fade-up motion-reduce:animate-none"
+      style={{ animationDelay: `${index * 16}ms` }}
+    >
+      <span
+        aria-hidden="true"
+        className={cn('text-[8px] leading-none select-none', peer.reachable ? 'text-ok' : 'text-destructive')}
+        title={peer.reachable ? 'reachable' : 'unreachable'}
+      >
+        ◆
+      </span>
+
+      {/* Identity */}
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-[14px] font-bold text-foreground truncate" title={peer.did}>
+          {shortDid(peer.did)}
+        </span>
+        <CopyButton value={peer.did} label="did" />
+        <a
+          href={peer.http_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="md:hidden text-[11px] text-dim truncate hover:text-foreground transition-colors"
+        >
+          {peerHost(peer.http_url)}
+        </a>
+      </div>
+
+      {/* Host */}
+      <a
+        href={peer.http_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hidden md:block text-[12px] text-muted-foreground truncate hover:text-warm-text transition-colors"
+        title={peer.http_url}
+      >
+        {peerHost(peer.http_url)} ↗
+      </a>
+
+      {/* Last seen */}
+      <span className="hidden md:block text-[12px] text-dim tabular-nums whitespace-nowrap">
+        {peer.last_seen ? timeAgo(peer.last_seen) : 'never'}
+      </span>
+
+      {/* Ping */}
+      <span className="justify-self-end">
+        <PingCell did={peer.did} />
+      </span>
+    </li>
+  );
+}
+
+function PeerRowSkeleton() {
+  return (
+    <li className="grid grid-cols-[16px_minmax(0,1fr)_70px] md:grid-cols-[24px_minmax(0,4fr)_minmax(0,3fr)_120px_90px]
+      items-center gap-x-3 md:gap-x-4 px-4 sm:px-6 py-3 border-b border-border-inner last:border-b-0">
+      <span />
+      <Skeleton className="h-4 w-40 max-w-full" />
+      <Skeleton className="hidden md:block h-4 w-36" />
+      <Skeleton className="hidden md:block h-4 w-16" />
+      <Skeleton className="h-6 w-14 justify-self-end" />
+    </li>
+  );
+}
+
+interface PeerListProps {
+  peers: ApiPeer[] | null;
+  loading?: boolean;
+  skeletonCount?: number;
+}
+
+export function PeerList({ peers, loading = false, skeletonCount = 10 }: PeerListProps) {
+  return (
+    <div className={cn(
+      'border border-border transition-opacity duration-200',
+      loading && peers !== null && 'opacity-40 pointer-events-none',
+    )}>
+      <div className="hidden md:grid grid-cols-[24px_minmax(0,4fr)_minmax(0,3fr)_120px_90px] gap-x-4 px-6 h-10 items-center border-b border-border bg-surface">
+        <span />
+        <MicroLabel>peer</MicroLabel>
+        <MicroLabel>endpoint</MicroLabel>
+        <MicroLabel>last seen</MicroLabel>
+        <MicroLabel className="text-right">check</MicroLabel>
+      </div>
+
+      {peers === null ? (
+        <ul className="m-0 p-0 list-none" aria-busy="true" aria-label="loading peers">
+          {Array.from({ length: skeletonCount }, (_, i) => <PeerRowSkeleton key={i} />)}
+        </ul>
+      ) : peers.length === 0 ? (
+        <p className="m-0 py-20 text-center text-[13px] text-muted-foreground">no peers match</p>
+      ) : (
+        <ul className="m-0 p-0 list-none">
+          {peers.map((peer, i) => <PeerRow key={peer.did} peer={peer} index={i} />)}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/repos/RepoHero.tsx
+++ b/src/components/repos/RepoHero.tsx
@@ -16,6 +16,8 @@ interface RepoHeroProps {
   description?: React.ReactNode;
   countNoun?: string;
   statLabel?: string;
+  /** Replaces the default count/page/per-page/window cells (first 4 render in the 2×2 box). */
+  cells?: { label: string; value: string }[];
 }
 
 function StatCell({ label, value, className }: { label: string; value: string; className?: string }) {
@@ -52,7 +54,17 @@ export function RepoHero({
   description,
   countNoun = 'repos',
   statLabel = 'visible repos',
+  cells,
 }: RepoHeroProps) {
+  const statCells = cells ?? [
+    { label: statLabel, value: totalCount > 0 ? totalCount.toLocaleString() : '—' },
+    { label: 'page', value: String(page) },
+    { label: 'per page', value: String(perPage) },
+    {
+      label: 'window',
+      value: totalCount > 0 ? `${windowStart.toLocaleString()}–${windowEnd.toLocaleString()}` : '—',
+    },
+  ];
   return (
     <section className="mt-6 sm:mt-8 border border-border grid-lines">
 
@@ -89,14 +101,14 @@ export function RepoHero({
 
         {/* 2×2 stats box */}
         <div className="grid grid-cols-2 border border-border shrink-0 w-full sm:w-[420px]">
-          <StatCell label={statLabel} value={totalCount > 0 ? totalCount.toLocaleString() : '—'} />
-          <StatCell label="page" value={String(page)} className="border-l border-border" />
-          <StatCell label="per page" value={String(perPage)} className="border-t border-border" />
-          <StatCell
-            label="window"
-            value={totalCount > 0 ? `${windowStart.toLocaleString()}–${windowEnd.toLocaleString()}` : '—'}
-            className="border-l border-t border-border"
-          />
+          {statCells.slice(0, 4).map((cell, i) => (
+            <StatCell
+              key={cell.label}
+              label={cell.label}
+              value={cell.value}
+              className={cn(i % 2 === 1 && 'border-l border-border', i >= 2 && 'border-t border-border')}
+            />
+          ))}
         </div>
       </div>
 

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -1,0 +1,112 @@
+import { Link } from 'react-router-dom';
+import { cn } from '../../lib/utils';
+import type { ApiTask } from '../../lib/api';
+import { taskTitle, shortDid, timeAgo } from '../../lib/api';
+import { taskStatusColor } from './status';
+import { MicroLabel } from '../ui/MicroLabel';
+import { Skeleton } from '../ui/Skeleton';
+
+function TaskRow({ task, index }: { task: ApiTask; index: number }) {
+  return (
+    <li
+      className="border-b border-border-inner last:border-b-0 hover:bg-hover transition-colors
+        animate-fade-up motion-reduce:animate-none"
+      style={{ animationDelay: `${index * 16}ms` }}
+    >
+      <Link
+        to={`/tasks/${task.id}`}
+        className="grid grid-cols-[16px_minmax(0,1fr)_80px] md:grid-cols-[24px_minmax(0,1fr)_150px_150px_90px]
+          items-baseline gap-x-3 md:gap-x-4 px-4 sm:px-6 py-3
+          focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warm"
+      >
+        <span
+          aria-hidden="true"
+          className={cn('text-[8px] leading-none select-none self-start pt-[5px]', taskStatusColor(task.status))}
+          title={task.status}
+        >
+          ◆
+        </span>
+
+        {/* Title + kind/capability */}
+        <span className="min-w-0">
+          <span className="block truncate text-[13px] font-bold text-foreground">{taskTitle(task)}</span>
+          <span className="block mt-0.5 text-[11px] text-dim truncate">
+            {task.kind}
+            {task.capability && <> · {task.capability}</>}
+            <span className="md:hidden"> · {task.status}</span>
+          </span>
+        </span>
+
+        {/* Delegator */}
+        <span className="hidden md:block text-[12px] text-muted-foreground truncate" title={task.delegator_did}>
+          {shortDid(task.delegator_did)} →
+        </span>
+
+        {/* Assignee */}
+        <span
+          className={cn('hidden md:block text-[12px] truncate', task.assignee_did ? 'text-muted-foreground' : 'text-dim')}
+          title={task.assignee_did ?? undefined}
+        >
+          {task.assignee_did ? shortDid(task.assignee_did) : 'unclaimed'}
+        </span>
+
+        {/* Time */}
+        <span className="text-[11px] text-dim tabular-nums text-right whitespace-nowrap">
+          {timeAgo(task.created_at)}
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+function TaskRowSkeleton() {
+  return (
+    <li className="grid grid-cols-[16px_minmax(0,1fr)_80px] md:grid-cols-[24px_minmax(0,1fr)_150px_150px_90px]
+      items-center gap-x-3 md:gap-x-4 px-4 sm:px-6 py-3 border-b border-border-inner last:border-b-0">
+      <span />
+      <div>
+        <Skeleton className="h-4 w-64 max-w-full" />
+        <Skeleton className="h-3 w-32 mt-1.5" />
+      </div>
+      <Skeleton className="hidden md:block h-4 w-24" />
+      <Skeleton className="hidden md:block h-4 w-24" />
+      <Skeleton className="h-3 w-14 justify-self-end" />
+    </li>
+  );
+}
+
+interface TaskListProps {
+  tasks: ApiTask[] | null;
+  loading?: boolean;
+  skeletonCount?: number;
+  emptyMessage?: string;
+}
+
+export function TaskList({ tasks, loading = false, skeletonCount = 10, emptyMessage = 'no tasks match' }: TaskListProps) {
+  return (
+    <div className={cn(
+      'border border-border transition-opacity duration-200',
+      loading && tasks !== null && 'opacity-40 pointer-events-none',
+    )}>
+      <div className="hidden md:grid grid-cols-[24px_minmax(0,1fr)_150px_150px_90px] gap-x-4 px-6 h-10 items-center border-b border-border bg-surface">
+        <span />
+        <MicroLabel>task</MicroLabel>
+        <MicroLabel>delegator</MicroLabel>
+        <MicroLabel>assignee</MicroLabel>
+        <MicroLabel className="text-right">created</MicroLabel>
+      </div>
+
+      {tasks === null ? (
+        <ul className="m-0 p-0 list-none" aria-busy="true" aria-label="loading tasks">
+          {Array.from({ length: skeletonCount }, (_, i) => <TaskRowSkeleton key={i} />)}
+        </ul>
+      ) : tasks.length === 0 ? (
+        <p className="m-0 py-20 text-center text-[13px] text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="m-0 p-0 list-none">
+          {tasks.map((task, i) => <TaskRow key={task.id} task={task} index={i} />)}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/tasks/status.ts
+++ b/src/components/tasks/status.ts
@@ -1,0 +1,17 @@
+import type { TaskStatus } from '../../lib/api';
+
+export const TASK_STATUSES: TaskStatus[] = ['pending', 'claimed', 'completed', 'failed'];
+
+/** Diamond-dot color per task status (matches the agent/peer dot idiom). */
+export function taskStatusColor(status: string): string {
+  switch (status) {
+    case 'claimed':
+      return 'text-warm';
+    case 'completed':
+      return 'text-ok';
+    case 'failed':
+      return 'text-destructive';
+    default: // pending & unknown
+      return 'text-status-dot';
+  }
+}

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Visibility-aware polling tick: increments `tick` every `intervalMs` while
+ * enabled and the tab is visible, and fires immediately on tab re-focus so a
+ * stale page catches up without waiting a full interval.
+ */
+export function useAutoRefresh(intervalMs: number, enabled: boolean): number {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (timer === null) timer = setInterval(() => setTick(t => t + 1), intervalMs);
+    };
+    const stop = () => {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        setTick(t => t + 1);
+        start();
+      }
+    };
+
+    if (!document.hidden) start();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [intervalMs, enabled]);
+
+  return tick;
+}

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect, useMemo } from 'react';
+import { FEDERATED_NODES, fetchNodeSnapshot } from '../lib/nodes';
+import type { NodeSnapshot } from '../lib/nodes';
+import { analyzeReplication, toEventTuples } from '../lib/replication';
+import type { ReplicationStatus } from '../lib/replication';
+import { useAutoRefresh } from './useAutoRefresh';
+
+interface Result {
+  snapshots: NodeSnapshot[] | null;
+  replication: ReplicationStatus | null;
+  loading: boolean;
+}
+
+/**
+ * Fans out to every federated node in parallel and derives replication
+ * coverage from the nodes' ref-update feeds. Unreachable nodes stay in the
+ * result (rendered as offline) and are excluded from replication analysis.
+ */
+export function useNetwork(refreshKey = 0): Result {
+  const tick = useAutoRefresh(60_000, true);
+  const [snapshots, setSnapshots] = useState<NodeSnapshot[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [prevRefreshKey, setPrevRefreshKey] = useState(refreshKey);
+  if (prevRefreshKey !== refreshKey) {
+    setPrevRefreshKey(refreshKey);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Promise.all(FEDERATED_NODES.map(n => fetchNodeSnapshot(n, controller.signal)))
+      .then(snaps => {
+        if (controller.signal.aborted) return;
+        setSnapshots(snaps);
+        setLoading(false);
+      })
+      .catch(() => {
+        // fetchNodeSnapshot never rejects except on abort.
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [refreshKey, tick]);
+
+  const replication = useMemo(() => {
+    if (!snapshots) return null;
+    const feeds = snapshots
+      .filter(s => s.events !== null)
+      .map(s => ({
+        label: s.node.label,
+        did: s.info?.did ?? '',
+        feed: toEventTuples(s.events ?? []),
+      }));
+    if (feeds.length < 2) return null;
+    return analyzeReplication(feeds);
+  }, [snapshots]);
+
+  return { snapshots, replication, loading };
+}

--- a/src/hooks/useNodeOverview.ts
+++ b/src/hooks/useNodeOverview.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import {
+  fetchNodeInfo,
+  fetchStats,
+  fetchPeers,
+  fetchP2PInfo,
+  fetchRefUpdates,
+  fetchTasks,
+  fetchRepos,
+} from '../lib/api';
+import type { NodeInfo, NodeStats, ApiPeer, P2PInfo, ApiRefUpdate, ApiTask, ApiRepo } from '../lib/api';
+import { useAutoRefresh } from './useAutoRefresh';
+
+export interface NodeOverview {
+  node: NodeInfo | null;
+  stats: NodeStats | null;
+  peers: ApiPeer[] | null;
+  p2p: P2PInfo | null;
+  events: ApiRefUpdate[] | null;
+  tasks: ApiTask[] | null;
+  recentRepos: ApiRepo[] | null;
+  loading: boolean;
+  /** True when every sub-fetch failed — the node is unreachable. */
+  unreachable: boolean;
+}
+
+const nullOnError = <T,>(p: Promise<T>): Promise<T | null> => p.catch(() => null);
+
+/**
+ * One parallel sweep of the dashboard's data. Each sub-fetch degrades
+ * independently (a failed corner renders as "—", never breaks the page) and
+ * the whole sweep re-runs on a visibility-aware 60s tick.
+ */
+export function useNodeOverview(refreshKey = 0): NodeOverview {
+  const tick = useAutoRefresh(60_000, true);
+  const [state, setState] = useState<Omit<NodeOverview, 'loading' | 'unreachable'>>({
+    node: null,
+    stats: null,
+    peers: null,
+    p2p: null,
+    events: null,
+    tasks: null,
+    recentRepos: null,
+  });
+  const [loaded, setLoaded] = useState(false);
+
+  // Render-phase reset on manual refresh only (ticks refresh in place).
+  const [prevRefreshKey, setPrevRefreshKey] = useState(refreshKey);
+  if (prevRefreshKey !== refreshKey) {
+    setPrevRefreshKey(refreshKey);
+    setLoaded(false);
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    Promise.all([
+      nullOnError(fetchNodeInfo(signal)),
+      nullOnError(fetchStats(signal)),
+      nullOnError(fetchPeers(signal)),
+      nullOnError(fetchP2PInfo(signal)),
+      nullOnError(fetchRefUpdates(50, signal)),
+      nullOnError(fetchTasks({ signal })),
+      nullOnError(fetchRepos({ limit: 4, offset: 0, signal }).then(r => r.repos)),
+    ]).then(([node, stats, peers, p2p, events, tasks, recentRepos]) => {
+      if (signal.aborted) return;
+      setState({ node, stats, peers, p2p, events, tasks, recentRepos });
+      setLoaded(true);
+    });
+
+    return () => controller.abort();
+  }, [refreshKey, tick]);
+
+  const unreachable =
+    loaded &&
+    !state.node && !state.stats && !state.peers && !state.p2p &&
+    !state.events && !state.tasks && !state.recentRepos;
+
+  return { ...state, loading: !loaded, unreachable };
+}

--- a/src/hooks/usePeers.ts
+++ b/src/hooks/usePeers.ts
@@ -1,0 +1,105 @@
+import { useState, useEffect, useMemo } from 'react';
+import { fetchPeers, fetchP2PInfo, peerHost } from '../lib/api';
+import type { ApiPeer, P2PInfo } from '../lib/api';
+import { useDebouncedValue } from './useDebouncedValue';
+import { useAutoRefresh } from './useAutoRefresh';
+
+interface Options {
+  page: number;
+  perPage: number;
+  search?: string;
+  refreshKey?: number;
+}
+
+interface Result {
+  peers: ApiPeer[] | null;
+  p2p: P2PInfo | null;
+  allCount: number;
+  reachableCount: number;
+  totalCount: number;
+  totalPages: number;
+  windowStart: number;
+  windowEnd: number;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Peer directory: full list fetched per sweep (the endpoint is unpaginated),
+ * filtered/paged client-side, re-fetched on a visibility-aware 60s tick.
+ * Reachable peers sort first, then by most recent last_seen.
+ */
+export function usePeers({ page, perPage, search = '', refreshKey = 0 }: Options): Result {
+  const tick = useAutoRefresh(60_000, true);
+  const [all, setAll] = useState<ApiPeer[] | null>(null);
+  const [p2p, setP2p] = useState<P2PInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const debouncedSearch = useDebouncedValue(search.trim().toLowerCase(), 300);
+
+  const [prevRefreshKey, setPrevRefreshKey] = useState(refreshKey);
+  if (prevRefreshKey !== refreshKey) {
+    setPrevRefreshKey(refreshKey);
+    setLoading(true);
+    setError(null);
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Promise.all([
+      fetchPeers(controller.signal),
+      fetchP2PInfo(controller.signal).catch(() => null),
+    ])
+      .then(([peers, p2pInfo]) => {
+        if (controller.signal.aborted) return;
+        setAll(peers);
+        setP2p(p2pInfo);
+        setLoading(false);
+      })
+      .catch(err => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load peers');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [refreshKey, tick]);
+
+  const derived = useMemo(() => {
+    if (!all) {
+      return {
+        peers: null, allCount: 0, reachableCount: 0,
+        totalCount: 0, totalPages: 1, windowStart: 0, windowEnd: 0,
+      };
+    }
+    const sorted = [...all].sort((a, b) => {
+      if (a.reachable !== b.reachable) return a.reachable ? -1 : 1;
+      return (b.last_seen ?? '').localeCompare(a.last_seen ?? '');
+    });
+    const filtered = debouncedSearch
+      ? sorted.filter(
+          p =>
+            p.did.toLowerCase().includes(debouncedSearch) ||
+            peerHost(p.http_url).toLowerCase().includes(debouncedSearch),
+        )
+      : sorted;
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
+    const safePage = Math.min(page, totalPages);
+    const start = (safePage - 1) * perPage;
+    const peers = filtered.slice(start, start + perPage);
+
+    return {
+      peers,
+      allCount: all.length,
+      reachableCount: all.filter(p => p.reachable).length,
+      totalCount,
+      totalPages,
+      windowStart: totalCount === 0 ? 0 : start + 1,
+      windowEnd: Math.min(start + perPage, totalCount),
+    };
+  }, [all, debouncedSearch, page, perPage]);
+
+  return { ...derived, p2p, loading, error };
+}

--- a/src/hooks/useRefUpdates.ts
+++ b/src/hooks/useRefUpdates.ts
@@ -1,0 +1,104 @@
+import { useState, useEffect, useMemo } from 'react';
+import { fetchRefUpdates, MAX_EVENT_LIMIT, isGossip } from '../lib/api';
+import type { ApiRefUpdate } from '../lib/api';
+import { useDebouncedValue } from './useDebouncedValue';
+import { useAutoRefresh } from './useAutoRefresh';
+
+export type EventSourceFilter = 'all' | 'local' | 'gossip';
+
+interface Options {
+  page: number;
+  perPage: number;
+  search?: string;
+  source?: EventSourceFilter;
+  /** Auto-refresh the feed (visibility-aware, 30s). */
+  live?: boolean;
+  refreshKey?: number;
+}
+
+interface Result {
+  events: ApiRefUpdate[] | null;
+  allCount: number;
+  gossipCount: number;
+  latest: ApiRefUpdate | null;
+  totalCount: number;
+  totalPages: number;
+  windowStart: number;
+  windowEnd: number;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useRefUpdates({
+  page, perPage, search = '', source = 'all', live = true, refreshKey = 0,
+}: Options): Result {
+  const tick = useAutoRefresh(30_000, live);
+  const [all, setAll] = useState<ApiRefUpdate[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const debouncedSearch = useDebouncedValue(search.trim().toLowerCase(), 300);
+
+  const [prevRefreshKey, setPrevRefreshKey] = useState(refreshKey);
+  if (prevRefreshKey !== refreshKey) {
+    setPrevRefreshKey(refreshKey);
+    setLoading(true);
+    setError(null);
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchRefUpdates(MAX_EVENT_LIMIT, controller.signal)
+      .then(events => {
+        if (controller.signal.aborted) return;
+        setAll(events);
+        setLoading(false);
+        setError(null);
+      })
+      .catch(err => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load events');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [refreshKey, tick]);
+
+  const derived = useMemo(() => {
+    if (!all) {
+      return {
+        events: null, allCount: 0, gossipCount: 0, latest: null,
+        totalCount: 0, totalPages: 1, windowStart: 0, windowEnd: 0,
+      };
+    }
+    let filtered = all;
+    if (source !== 'all') {
+      filtered = filtered.filter(e => (source === 'gossip') === isGossip(e));
+    }
+    if (debouncedSearch) {
+      filtered = filtered.filter(
+        e =>
+          e.repo.toLowerCase().includes(debouncedSearch) ||
+          e.ref_name.toLowerCase().includes(debouncedSearch) ||
+          e.pusher_did.toLowerCase().includes(debouncedSearch),
+      );
+    }
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
+    const safePage = Math.min(page, totalPages);
+    const start = (safePage - 1) * perPage;
+
+    return {
+      events: filtered.slice(start, start + perPage),
+      allCount: all.length,
+      gossipCount: all.filter(isGossip).length,
+      latest: all[0] ?? null,
+      totalCount,
+      totalPages,
+      windowStart: totalCount === 0 ? 0 : start + 1,
+      windowEnd: Math.min(start + perPage, totalCount),
+    };
+  }, [all, debouncedSearch, source, page, perPage]);
+
+  return { ...derived, loading, error };
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,0 +1,92 @@
+import { useState, useEffect, useMemo } from 'react';
+import { fetchTasks, taskTitle } from '../lib/api';
+import type { ApiTask, TaskStatus } from '../lib/api';
+import { useDebouncedValue } from './useDebouncedValue';
+import { useAutoRefresh } from './useAutoRefresh';
+
+interface Options {
+  page: number;
+  perPage: number;
+  /** Server-side filter — refetches when it changes. */
+  status?: TaskStatus;
+  search?: string;
+  refreshKey?: number;
+}
+
+interface Result {
+  tasks: ApiTask[] | null;
+  allCount: number;
+  totalCount: number;
+  totalPages: number;
+  windowStart: number;
+  windowEnd: number;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useTasks({ page, perPage, status, search = '', refreshKey = 0 }: Options): Result {
+  const tick = useAutoRefresh(30_000, true);
+  const [all, setAll] = useState<ApiTask[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const debouncedSearch = useDebouncedValue(search.trim().toLowerCase(), 300);
+
+  // Render-phase reset when the fetch key changes (manual refresh or filter).
+  const fetchKey = `${refreshKey}|${status ?? ''}`;
+  const [prevFetchKey, setPrevFetchKey] = useState(fetchKey);
+  if (prevFetchKey !== fetchKey) {
+    setPrevFetchKey(fetchKey);
+    setLoading(true);
+    setError(null);
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchTasks({ status, signal: controller.signal })
+      .then(tasks => {
+        if (controller.signal.aborted) return;
+        setAll(tasks);
+        setLoading(false);
+        setError(null);
+      })
+      .catch(err => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load tasks');
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [refreshKey, status, tick]);
+
+  const derived = useMemo(() => {
+    if (!all) {
+      return { tasks: null, allCount: 0, totalCount: 0, totalPages: 1, windowStart: 0, windowEnd: 0 };
+    }
+    const filtered = debouncedSearch
+      ? all.filter(
+          t =>
+            t.kind.toLowerCase().includes(debouncedSearch) ||
+            taskTitle(t).toLowerCase().includes(debouncedSearch) ||
+            t.delegator_did.toLowerCase().includes(debouncedSearch) ||
+            (t.assignee_did ?? '').toLowerCase().includes(debouncedSearch) ||
+            t.capability.toLowerCase().includes(debouncedSearch),
+        )
+      : all;
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
+    const safePage = Math.min(page, totalPages);
+    const start = (safePage - 1) * perPage;
+
+    return {
+      tasks: filtered.slice(start, start + perPage),
+      allCount: all.length,
+      totalCount,
+      totalPages,
+      windowStart: totalCount === 0 ? 0 : start + 1,
+      windowEnd: Math.min(start + perPage, totalCount),
+    };
+  }, [all, debouncedSearch, page, perPage]);
+
+  return { ...derived, loading, error };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -150,6 +150,14 @@ body {
 
 /* ── Terminal utilities ────────────────────────────────────────────────────── */
 
+/* Hide scrollbars on horizontally scrollable chrome (section tab bar) */
+.scrollbar-none {
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 /* Uppercase letter-spaced micro-label, as in the reference mockups */
 .micro-label {
   font-size: 10px;

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -13,9 +13,86 @@ import {
   getBlob,
   blobUrl,
   MAX_INLINE_BYTES,
+  peerHost,
+  shortRefName,
+  parseEventRepo,
+  taskTitle,
+  prettyJson,
   type ApiRepo,
   type ApiTreeEntry,
 } from './api';
+
+describe('peerHost', () => {
+  it('reduces a URL to its host', () => {
+    expect(peerHost('https://node2.gitlawb.com')).toBe('node2.gitlawb.com');
+  });
+
+  it('keeps non-default ports', () => {
+    expect(peerHost('http://10.0.0.5:7545/path')).toBe('10.0.0.5:7545');
+  });
+
+  it('degrades gracefully on unparseable input', () => {
+    expect(peerHost('not a url')).toBe('not a url');
+  });
+});
+
+describe('shortRefName', () => {
+  it('strips refs/heads/ to the branch name', () => {
+    expect(shortRefName('refs/heads/main')).toBe('main');
+  });
+
+  it('keeps non-branch refs recognizable', () => {
+    expect(shortRefName('refs/pull/997/merge')).toBe('pull/997/merge');
+  });
+
+  it('passes through bare names', () => {
+    expect(shortRefName('main')).toBe('main');
+  });
+});
+
+describe('parseEventRepo', () => {
+  it('splits owner key and repo name into a linkable ref', () => {
+    const ref = parseEventRepo('z6MkvLongOwnerKey123/hello-world');
+    expect(ref).toEqual({
+      ownerDid: 'did:key:z6MkvLongOwnerKey123',
+      name: 'hello-world',
+      label: 'z6MkvLon/hello-world',
+    });
+  });
+
+  it('keeps an existing did: prefix', () => {
+    expect(parseEventRepo('did:key:z6Mk/name')?.ownerDid).toBe('did:key:z6Mk');
+  });
+
+  it('returns null for values without an owner/name shape', () => {
+    expect(parseEventRepo('justaname')).toBeNull();
+    expect(parseEventRepo('/leading')).toBeNull();
+    expect(parseEventRepo('trailing/')).toBeNull();
+  });
+});
+
+describe('taskTitle', () => {
+  it('prefers the payload JSON title', () => {
+    expect(taskTitle({ kind: 'deploy', payload: '{"title":"Deploy: scan PRs"}' })).toBe('Deploy: scan PRs');
+  });
+
+  it('falls back to kind when payload is missing, malformed, or untitled', () => {
+    expect(taskTitle({ kind: 'deploy', payload: null })).toBe('deploy');
+    expect(taskTitle({ kind: 'deploy', payload: 'not json' })).toBe('deploy');
+    expect(taskTitle({ kind: 'deploy', payload: '{"x":1}' })).toBe('deploy');
+    expect(taskTitle({ kind: 'deploy', payload: '{"title":"  "}' })).toBe('deploy');
+  });
+});
+
+describe('prettyJson', () => {
+  it('pretty-prints valid JSON', () => {
+    expect(prettyJson('{"a":1}')).toBe('{\n  "a": 1\n}');
+  });
+
+  it('returns non-JSON input unchanged', () => {
+    expect(prettyJson('plain text')).toBe('plain text');
+  });
+});
 
 describe('shortDid', () => {
   it('returns the last DID segment truncated to 8 chars', () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -103,12 +103,65 @@ export interface NodeStats {
   version: string;
 }
 
+export interface ApiPeer {
+  did: string;
+  http_url: string;
+  last_seen: string | null;
+  reachable: boolean;
+}
+
+export interface P2PInfo {
+  enabled: boolean;
+  peer_id?: string;
+  topics?: string[];
+  connected_peers?: number | null;
+  gossipsub_mesh_peers?: number | null;
+  gossipsub_all_peers?: number | null;
+  listen_addrs?: string[] | null;
+}
+
+/** Node-level ref-update event from GET /events/ref-updates. */
+export interface ApiRefUpdate {
+  id: string;
+  node_did: string;
+  pusher_did: string;
+  /** "{full_owner_key}/{repo_name}" — see parseEventRepo. */
+  repo: string;
+  ref_name: string;
+  old_sha: string;
+  new_sha: string;
+  timestamp: string;
+  cert_id: string | null;
+  received_at: string;
+  /** null/empty for pushes received by this node; set when gossiped from a peer. */
+  from_peer: string | null;
+}
+
+export type TaskStatus = 'pending' | 'claimed' | 'completed' | 'failed';
+
+export interface ApiTask {
+  id: string;
+  repo_id: string | null;
+  kind: string;
+  status: TaskStatus | string;
+  delegator_did: string;
+  assignee_did: string | null;
+  capability: string;
+  ucan_token: string | null;
+  payload: string | null;
+  result: string | null;
+  created_at: string;
+  updated_at: string;
+  deadline: string | null;
+}
+
 export interface NodeInfo {
   name: string;
   did: string;
   version: string;
   network: string;
   protocols: string[];
+  p2p_peer_id?: string | null;
 }
 
 export interface RepoListParams {
@@ -289,6 +342,54 @@ export async function fetchCerts(owner: string, name: string, signal?: AbortSign
   return data.certificates ?? [];
 }
 
+export async function fetchPeers(signal?: AbortSignal): Promise<ApiPeer[]> {
+  const data = await getJson<{ peers?: ApiPeer[] }>(`${BASE_URL}/peers`, signal);
+  return data.peers ?? [];
+}
+
+export function fetchP2PInfo(signal?: AbortSignal): Promise<P2PInfo> {
+  return getJson<P2PInfo>(`${BASE_URL}/p2p/info`, signal);
+}
+
+export async function pingPeer(did: string, signal?: AbortSignal): Promise<boolean> {
+  const data = await getJson<{ reachable?: boolean }>(
+    `${BASE_URL}/peers/${encodeURIComponent(did)}/ping`,
+    signal,
+  );
+  return data.reachable === true;
+}
+
+// Server clamps ref-update limit to 200 (node: api/events.rs).
+export const MAX_EVENT_LIMIT = 200;
+
+export async function fetchRefUpdates(limit = MAX_EVENT_LIMIT, signal?: AbortSignal): Promise<ApiRefUpdate[]> {
+  const data = await getJson<{ events?: ApiRefUpdate[] }>(
+    `${BASE_URL}/events/ref-updates?limit=${limit}`,
+    signal,
+  );
+  return data.events ?? [];
+}
+
+export interface TaskListParams {
+  status?: TaskStatus;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+export async function fetchTasks({ status, limit = 200, signal }: TaskListParams = {}): Promise<ApiTask[]> {
+  const search = new URLSearchParams({ limit: String(limit) });
+  if (status) search.set('status', status);
+  const data = await getJson<{ tasks?: ApiTask[] }>(`${BASE_URL}/tasks?${search}`, signal);
+  return data.tasks ?? [];
+}
+
+export async function fetchTask(id: string, signal?: AbortSignal): Promise<ApiTask> {
+  const res = await fetch(`${BASE_URL}/tasks/${encodeURIComponent(id)}`, { signal });
+  if (res.status === 404) throw new Error('not_found');
+  if (!res.ok) throw new Error(`Failed to fetch task: ${res.status}`);
+  return res.json() as Promise<ApiTask>;
+}
+
 /** Short display form of a DID: last segment after ':', truncated (mockups show `z6Mkv79S/`). */
 export function shortDid(did: string): string {
   const seg = did.split(':').pop() ?? did;
@@ -323,6 +424,77 @@ export function trustTier(score: number): string {
 
 export function shortSha(sha: string): string {
   return sha ? sha.slice(0, 7) : '—';
+}
+
+/** Host (and non-default port) of a peer URL, for compact display. */
+export function peerHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+  }
+}
+
+/** `refs/heads/main` → `main`; other refs lose only the `refs/` prefix. */
+export function shortRefName(ref: string): string {
+  if (ref.startsWith('refs/heads/')) return ref.slice('refs/heads/'.length);
+  if (ref.startsWith('refs/')) return ref.slice('refs/'.length);
+  return ref;
+}
+
+/** An event is "gossip" when it arrived from a peer rather than a local push. */
+export function isGossip(event: Pick<ApiRefUpdate, 'from_peer'>): boolean {
+  return Boolean(event.from_peer);
+}
+
+export interface EventRepoRef {
+  /** Full DID usable in /repos/:owner/:name links (`did:key:` + key part). */
+  ownerDid: string;
+  name: string;
+  /** Short owner segment for display (`z6Mkv79S/name`). */
+  label: string;
+}
+
+/**
+ * Ref-update events store repo as "{full_owner_key}/{repo_name}" (node:
+ * api/events.rs). Returns null when the field doesn't match that shape.
+ */
+export function parseEventRepo(repo: string): EventRepoRef | null {
+  const slash = repo.indexOf('/');
+  if (slash <= 0 || slash === repo.length - 1) return null;
+  const key = repo.slice(0, slash);
+  const name = repo.slice(slash + 1);
+  return {
+    ownerDid: key.startsWith('did:') ? key : `did:key:${key}`,
+    name,
+    label: `${key.length > 8 ? key.slice(0, 8) : key}/${name}`,
+  };
+}
+
+/**
+ * Human title for a task: agents put a `title` in the JSON payload; fall back
+ * to the task kind when absent or unparseable.
+ */
+export function taskTitle(task: Pick<ApiTask, 'kind' | 'payload'>): string {
+  if (task.payload) {
+    try {
+      const parsed: unknown = JSON.parse(task.payload);
+      if (parsed && typeof parsed === 'object' && 'title' in parsed) {
+        const title = (parsed as { title: unknown }).title;
+        if (typeof title === 'string' && title.trim()) return title;
+      }
+    } catch { /* fall through to kind */ }
+  }
+  return task.kind;
+}
+
+/** Pretty-print a JSON string for display; returns the input when not JSON. */
+export function prettyJson(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
 }
 
 export function timeAgo(isoString: string): string {

--- a/src/lib/nodes.ts
+++ b/src/lib/nodes.ts
@@ -1,0 +1,69 @@
+// Federated node registry for the network page. The nodes serve no CORS
+// headers, so peer nodes are reached through per-node proxy prefixes — see
+// vite.config.ts (dev) and vercel.json (prod), which must list the same hosts.
+import type { NodeInfo, NodeStats, ApiPeer, P2PInfo, ApiRefUpdate } from './api';
+
+export interface FederatedNode {
+  id: string;
+  /** Display label — the public host. */
+  label: string;
+  /** Public origin, for out-links. */
+  url: string;
+  /** Same-origin proxy prefix ('' = the primary node's default proxy). */
+  proxy: string;
+}
+
+export const FEDERATED_NODES: FederatedNode[] = [
+  { id: 'node1', label: 'node.gitlawb.com', url: 'https://node.gitlawb.com', proxy: '' },
+  { id: 'node2', label: 'node2.gitlawb.com', url: 'https://node2.gitlawb.com', proxy: '/nodes/node2' },
+  { id: 'node3', label: 'node3.gitlawb.com', url: 'https://node3.gitlawb.com', proxy: '/nodes/node3' },
+  { id: 'manila', label: 'manila.gitlawb.com', url: 'https://manila.gitlawb.com', proxy: '/nodes/manila' },
+];
+
+export interface NodeSnapshot {
+  node: FederatedNode;
+  reachable: boolean;
+  info: NodeInfo & { p2p_peer_id?: string | null } | null;
+  stats: NodeStats | null;
+  peers: ApiPeer[] | null;
+  p2p: P2PInfo | null;
+  events: ApiRefUpdate[] | null;
+}
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+const nullOnError = <T,>(p: Promise<T>): Promise<T | null> => p.catch(() => null);
+
+/**
+ * One parallel sweep of a node's public read surface. Every sub-fetch fails
+ * independently — a node is "reachable" if any call answered, so a partially
+ * degraded node still renders with whatever it returned.
+ */
+export async function fetchNodeSnapshot(node: FederatedNode, signal?: AbortSignal): Promise<NodeSnapshot> {
+  const api = `${node.proxy}/api/v1`;
+  const [info, stats, peers, p2p, events] = await Promise.all([
+    nullOnError(getJson<NodeSnapshot['info']>(`${node.proxy}/node-info`, signal)),
+    nullOnError(getJson<NodeStats>(`${api}/stats`, signal)),
+    nullOnError(getJson<{ peers?: ApiPeer[] }>(`${api}/peers`, signal).then(d => d.peers ?? [])),
+    nullOnError(getJson<P2PInfo>(`${api}/p2p/info`, signal)),
+    nullOnError(
+      getJson<{ events?: ApiRefUpdate[] }>(`${api}/events/ref-updates?limit=200`, signal).then(
+        d => d.events ?? [],
+      ),
+    ),
+  ]);
+
+  return {
+    node,
+    reachable: Boolean(info || stats || peers || p2p || events),
+    info,
+    stats,
+    peers,
+    p2p,
+    events,
+  };
+}

--- a/src/lib/replication.test.ts
+++ b/src/lib/replication.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeReplication, toEventTuples, tupleKey } from './replication';
+import type { ApiRefUpdate } from './api';
+
+const event = (overrides: Partial<ApiRefUpdate>): ApiRefUpdate => ({
+  id: 'e1',
+  node_did: 'did:key:origin',
+  pusher_did: 'did:key:pusher',
+  repo: 'z6MkKey/repo',
+  ref_name: 'refs/heads/main',
+  old_sha: '0'.repeat(40),
+  new_sha: 'a'.repeat(40),
+  timestamp: '2026-07-01T00:00:00Z',
+  cert_id: null,
+  received_at: '2026-07-01T00:00:01Z',
+  from_peer: null,
+  ...overrides,
+});
+
+describe('toEventTuples', () => {
+  it('keys tuples on origin/repo/ref/sha', () => {
+    const [t] = toEventTuples([event({})]);
+    expect(t.key).toBe(tupleKey('did:key:origin', 'z6MkKey/repo', 'refs/heads/main', 'a'.repeat(40)));
+  });
+});
+
+describe('analyzeReplication', () => {
+  const e1 = event({});
+  const e2 = event({ new_sha: 'b'.repeat(40), timestamp: '2026-07-02T00:00:00Z' });
+
+  it('marks the origin node and computes full coverage', () => {
+    const feeds = [
+      { label: 'n1', did: 'did:key:origin', feed: toEventTuples([e1]) },
+      { label: 'n2', did: 'did:key:other', feed: toEventTuples([e1]) },
+    ];
+    const status = analyzeReplication(feeds);
+    expect(status.totalTuples).toBe(1);
+    expect(status.coveragePercent).toBe(100);
+    expect(status.rows[0].presence).toEqual({ n1: 'origin', n2: 'replicated' });
+    expect(status.driftByNode).toEqual({ n1: 0, n2: 0 });
+  });
+
+  it('counts drift for nodes missing a tuple and sorts rows newest-first', () => {
+    const feeds = [
+      { label: 'n1', did: 'did:key:origin', feed: toEventTuples([e1, e2]) },
+      { label: 'n2', did: 'did:key:other', feed: toEventTuples([e1]) },
+    ];
+    const status = analyzeReplication(feeds);
+    expect(status.totalTuples).toBe(2);
+    expect(status.fullyReplicatedCount).toBe(1);
+    expect(status.coveragePercent).toBe(50);
+    expect(status.driftByNode.n2).toBe(1);
+    // newest (e2) first
+    expect(status.rows[0].tuple.new_sha).toBe('b'.repeat(40));
+    expect(status.rows[0].presence.n2).toBe('missing');
+  });
+
+  it('treats an origin outside the fan-out as replicated-only rows', () => {
+    const foreign = event({ node_did: 'did:key:unknown-node' });
+    const feeds = [
+      { label: 'n1', did: 'did:key:a', feed: toEventTuples([foreign]) },
+      { label: 'n2', did: 'did:key:b', feed: [] },
+    ];
+    const status = analyzeReplication(feeds);
+    expect(status.rows[0].presence).toEqual({ n1: 'replicated', n2: 'missing' });
+  });
+});

--- a/src/lib/replication.ts
+++ b/src/lib/replication.ts
@@ -1,0 +1,116 @@
+// Replication analysis over per-node ref-update feeds: for each distinct
+// (origin, repo, ref, sha) tuple, which nodes carry it? The origin node always
+// has the tuple (it received the push); others have it iff their gossip feed
+// contains it. Ported from the gitlawb.com web implementation.
+import type { ApiRefUpdate } from './api';
+
+export interface EventTuple {
+  key: string;
+  node_did: string;
+  repo: string;
+  ref_name: string;
+  new_sha: string;
+  timestamp: string;
+}
+
+export interface NodeFeed {
+  label: string;
+  /** The node's own DID (from node-info); '' when unknown. */
+  did: string;
+  feed: EventTuple[];
+}
+
+export type Presence = 'origin' | 'replicated' | 'missing';
+
+export interface ReplicationRow {
+  tuple: EventTuple;
+  presence: Record<string, Presence>;
+  fullyReplicated: boolean;
+}
+
+export interface ReplicationStatus {
+  rows: ReplicationRow[];
+  totalTuples: number;
+  fullyReplicatedCount: number;
+  coveragePercent: number;
+  driftByNode: Record<string, number>;
+  receivedByNode: Record<string, number>;
+  originatedByNode: Record<string, number>;
+}
+
+export function tupleKey(node_did: string, repo: string, ref_name: string, new_sha: string): string {
+  return `${node_did}|${repo}|${ref_name}|${new_sha}`;
+}
+
+export function toEventTuples(events: ApiRefUpdate[]): EventTuple[] {
+  return events.map(e => ({
+    key: tupleKey(e.node_did, e.repo, e.ref_name, e.new_sha),
+    node_did: e.node_did,
+    repo: e.repo,
+    ref_name: e.ref_name,
+    new_sha: e.new_sha,
+    timestamp: e.timestamp,
+  }));
+}
+
+export function analyzeReplication(feeds: NodeFeed[]): ReplicationStatus {
+  const tupleMap = new Map<string, EventTuple>();
+  const feedKeySets = new Map<string, Set<string>>();
+  const didToLabel = new Map<string, string>();
+
+  for (const f of feeds) {
+    feedKeySets.set(f.label, new Set(f.feed.map(t => t.key)));
+    if (f.did) didToLabel.set(f.did, f.label);
+    for (const t of f.feed) tupleMap.set(t.key, t);
+  }
+
+  const driftByNode: Record<string, number> = {};
+  const receivedByNode: Record<string, number> = {};
+  const originatedByNode: Record<string, number> = {};
+  for (const f of feeds) {
+    driftByNode[f.label] = 0;
+    receivedByNode[f.label] = f.feed.length;
+    originatedByNode[f.label] = 0;
+  }
+
+  const rows: ReplicationRow[] = [];
+  let fullyReplicatedCount = 0;
+
+  for (const t of tupleMap.values()) {
+    const originLabel = didToLabel.get(t.node_did);
+    if (originLabel) originatedByNode[originLabel] += 1;
+
+    const presence: Record<string, Presence> = {};
+    let presentCount = 0;
+    for (const f of feeds) {
+      let p: Presence;
+      if (f.did && f.did === t.node_did) {
+        p = 'origin';
+      } else if (feedKeySets.get(f.label)?.has(t.key)) {
+        p = 'replicated';
+      } else {
+        p = 'missing';
+      }
+      presence[f.label] = p;
+      if (p === 'missing') driftByNode[f.label] += 1;
+      else presentCount += 1;
+    }
+
+    const fullyReplicated = presentCount === feeds.length;
+    if (fullyReplicated) fullyReplicatedCount += 1;
+    rows.push({ tuple: t, presence, fullyReplicated });
+  }
+
+  rows.sort((a, b) => new Date(b.tuple.timestamp).getTime() - new Date(a.tuple.timestamp).getTime());
+
+  const total = tupleMap.size;
+  return {
+    rows,
+    totalTuples: total,
+    fullyReplicatedCount,
+    coveragePercent: total > 0 ? Math.round((100 * fullyReplicatedCount) / total) : 0,
+    driftByNode,
+    receivedByNode,
+    originatedByNode,
+  };
+}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -1,0 +1,187 @@
+import { useSearchParams } from 'react-router-dom';
+import { useCallback, useRef, useState } from 'react';
+import { useListNav } from '../hooks/useShortcuts';
+import { DEFAULT_PER_PAGE, PER_PAGE_OPTIONS } from '../lib/constants';
+import { useRefUpdates } from '../hooks/useRefUpdates';
+import type { EventSourceFilter } from '../hooks/useRefUpdates';
+import { useRefreshKey } from '../hooks/useRefreshKey';
+import { timeAgo, MAX_EVENT_LIMIT } from '../lib/api';
+import { RefUpdateList } from '../components/events/RefUpdateList';
+import { RepoPagination } from '../components/repos/RepoPagination';
+import { RepoHero } from '../components/repos/RepoHero';
+import { MicroLabel } from '../components/ui/MicroLabel';
+import { Pill } from '../components/ui/Pill';
+import { cn } from '../lib/utils';
+
+const SOURCES: EventSourceFilter[] = ['all', 'local', 'gossip'];
+
+export default function EventsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const search = searchParams.get('q') ?? '';
+  const rawSource = searchParams.get('src') as EventSourceFilter | null;
+  const source: EventSourceFilter = rawSource && SOURCES.includes(rawSource) ? rawSource : 'all';
+  const live = searchParams.get('live') !== 'off';
+  const rawPage = Number(searchParams.get('page'));
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+  const rawPer = Number(searchParams.get('per'));
+  const perPage = PER_PAGE_OPTIONS.includes(rawPer) ? rawPer : DEFAULT_PER_PAGE;
+
+  const { refreshKey, refresh } = useRefreshKey();
+
+  const setParams = useCallback(
+    (updates: Record<string, string | null>, replace = false) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev);
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null || value === '') next.delete(key);
+          else next.set(key, value);
+        }
+        return next;
+      }, { replace });
+    },
+    [setSearchParams],
+  );
+
+  const {
+    events, allCount, gossipCount, latest,
+    totalCount, totalPages, windowStart, windowEnd, loading, error,
+  } = useRefUpdates({ page, perPage, search, source, live, refreshKey });
+
+  const listRef = useRef<HTMLDivElement>(null);
+  useListNav(listRef);
+
+  const [searchValue, setSearchValue] = useState(search);
+  const [prevSearch, setPrevSearch] = useState(search);
+  if (prevSearch !== search) {
+    setPrevSearch(search);
+    const inputFocused =
+      typeof document !== 'undefined' && document.activeElement?.id === 'event-search';
+    if (!inputFocused && search !== searchValue) setSearchValue(search);
+  }
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12">
+
+      <RepoHero
+        totalCount={totalCount}
+        page={page}
+        perPage={perPage}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        refreshing={loading}
+        onRefresh={refresh}
+        title="events."
+        indexLabel="ref-update feed"
+        countNoun="events"
+        description={
+          <p className="m-0">
+            Every ref update this node knows about — pushes it received directly{' '}
+            (<span aria-hidden="true" className="text-status-dot">◆</span> local) and updates gossiped
+            in from peer nodes over libp2p{' '}
+            (<span aria-hidden="true" className="text-warm">◆</span> gossip). The feed keeps the
+            latest {MAX_EVENT_LIMIT} events{live ? ' and refreshes itself every 30s' : ''}.
+          </p>
+        }
+        cells={[
+          { label: 'in feed', value: allCount > 0 ? allCount.toLocaleString() : '—' },
+          { label: 'local', value: allCount > 0 ? (allCount - gossipCount).toLocaleString() : '—' },
+          { label: 'gossip', value: allCount > 0 ? gossipCount.toLocaleString() : '—' },
+          { label: 'latest', value: latest ? timeAgo(latest.timestamp) : '—' },
+        ]}
+      />
+
+      <div className="pt-8 pb-20">
+
+        {/* Toolbar: search + source filter + live toggle */}
+        <div className="flex flex-wrap items-end gap-x-6 gap-y-4 mb-4">
+          <div className="flex-1 min-w-[240px] max-w-[560px]">
+            <MicroLabel className="block mb-1.5">
+              <label htmlFor="event-search">search</label>
+            </MicroLabel>
+            <input
+              id="event-search"
+              type="search"
+              value={searchValue}
+              onChange={e => {
+                setSearchValue(e.target.value);
+                setParams({ q: e.target.value, page: null }, true);
+              }}
+              placeholder="search by repo, ref, or pusher…"
+              autoComplete="off"
+              spellCheck={false}
+              className={cn(
+                'w-full h-9 px-3 text-[13px] bg-transparent border border-border rounded-[2px]',
+                'text-foreground placeholder:text-dim',
+                'focus:outline-none focus-visible:ring-1 focus-visible:ring-warm focus:border-dim',
+                'transition-colors',
+              )}
+            />
+          </div>
+
+          <div>
+            <MicroLabel className="block mb-1.5">source</MicroLabel>
+            <div className="flex gap-1.5">
+              {SOURCES.map(s => (
+                <Pill
+                  key={s}
+                  active={source === s}
+                  onClick={() => setParams({ src: s === 'all' ? null : s, page: null })}
+                  aria-pressed={source === s}
+                >
+                  {s}
+                </Pill>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <MicroLabel className="block mb-1.5">feed</MicroLabel>
+            <Pill
+              active={live}
+              onClick={() => setParams({ live: live ? 'off' : null })}
+              aria-pressed={live}
+              title="auto-refresh every 30s while the tab is visible"
+            >
+              {live ? '◆ live' : 'paused'}
+            </Pill>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="border border-border py-16 text-center">
+            <p className="m-0 text-[13px] text-destructive mb-4">failed to load events: {error}</p>
+            <Pill onClick={refresh}>retry</Pill>
+          </div>
+        ) : (
+          <>
+            <div ref={listRef} className="border border-border">
+              <RefUpdateList
+                events={events}
+                loading={loading}
+                skeletonCount={Math.min(perPage, 12)}
+                emptyMessage={
+                  search || source !== 'all'
+                    ? 'no events match'
+                    : 'no ref updates yet — push a repo to this node to see activity'
+                }
+              />
+            </div>
+            <RepoPagination
+              page={page}
+              totalPages={totalPages}
+              perPage={perPage}
+              totalCount={totalCount}
+              windowStart={windowStart}
+              windowEnd={windowEnd}
+              onPageChange={p => setParams({ page: p <= 1 ? null : String(p) })}
+              onPerPageChange={n => setParams({ per: n === DEFAULT_PER_PAGE ? null : String(n), page: null })}
+              noun="events"
+            />
+          </>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,292 @@
+import { Link } from 'react-router-dom';
+import { cn } from '../lib/utils';
+import { useRefreshKey } from '../hooks/useRefreshKey';
+import { useNodeOverview } from '../hooks/useNodeOverview';
+import { taskTitle, truncateDid, timeAgo, shortDid } from '../lib/api';
+import { MicroLabel } from '../components/ui/MicroLabel';
+import { Pill } from '../components/ui/Pill';
+import { CopyButton } from '../components/ui/CopyButton';
+import { Skeleton } from '../components/ui/Skeleton';
+import { RefUpdateList } from '../components/events/RefUpdateList';
+import { TASK_STATUSES, taskStatusColor } from '../components/tasks/status';
+
+function RefreshIcon({ spinning }: { spinning: boolean }) {
+  return (
+    <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true"
+      className={spinning ? 'animate-spin-icon' : ''}>
+      <path d="M10.5 6A4.5 4.5 0 1 1 6 1.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+      <path d="M10.5 1.5v4H6.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function StatTile({ label, value, note, to, className }: {
+  label: string;
+  value: string | null;
+  note?: string;
+  to: string;
+  className?: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className={cn(
+        'block px-5 py-4 bg-background/60 hover:bg-hover transition-colors group',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warm',
+        className,
+      )}
+    >
+      <MicroLabel className="block mb-2 group-hover:text-foreground transition-colors">{label}</MicroLabel>
+      {value === null ? (
+        <Skeleton className="h-[22px] w-16" />
+      ) : (
+        <p className="m-0 text-[22px] font-bold leading-none tabular-nums text-foreground">{value}</p>
+      )}
+      {note && <p className="m-0 mt-1.5 text-[10px] text-dim">{note}</p>}
+    </Link>
+  );
+}
+
+function PanelHeader({ label, children }: { label: string; children?: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-4 sm:px-6 h-10 border-b border-border bg-surface">
+      <MicroLabel>{label}</MicroLabel>
+      {children}
+    </div>
+  );
+}
+
+function IdentityRow({ label, value, copy }: { label: string; value: string | null; copy?: string }) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <MicroLabel className="w-[72px] shrink-0">{label}</MicroLabel>
+      {value === null ? (
+        <Skeleton className="h-4 w-48" />
+      ) : (
+        <>
+          <span className="text-[12px] text-muted-foreground truncate" title={copy ?? value}>{value}</span>
+          {copy && <CopyButton value={copy} label={label} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function HomePage() {
+  const { refreshKey, refresh } = useRefreshKey();
+  const { node, stats, peers, p2p, events, tasks, recentRepos, loading, unreachable } =
+    useNodeOverview(refreshKey);
+
+  const online = node !== null || stats !== null;
+  const reachablePeers = peers?.filter(p => p.reachable).length;
+  const taskCounts = TASK_STATUSES.map(status => ({
+    status,
+    count: tasks?.filter(t => t.status === status).length ?? 0,
+  }));
+  const openTasks = tasks?.filter(t => t.status === 'pending' || t.status === 'claimed');
+  const latestTasks = tasks?.slice(0, 4) ?? [];
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12">
+
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <section className="mt-6 sm:mt-8 border border-border grid-lines">
+        <div className="flex items-center justify-between gap-3 px-4 sm:px-6 h-12 border-b border-border">
+          <MicroLabel>node overview</MicroLabel>
+          <div className="flex items-center gap-3">
+            {!loading && (
+              <span className={cn('text-[11px] flex items-center gap-1.5', online ? 'text-ok' : 'text-destructive')}>
+                <span aria-hidden="true" className="text-[8px]">◆</span>
+                {online ? 'online' : 'offline'}
+              </span>
+            )}
+            {node?.version && <Pill className="max-sm:hidden">v{node.version}</Pill>}
+            <Pill onClick={refresh} disabled={loading} aria-label="refresh overview">
+              <RefreshIcon spinning={loading} />
+              {loading ? 'refreshing' : 'refresh'}
+            </Pill>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row lg:items-start gap-8 px-4 sm:px-6 py-8 sm:py-10">
+          <div className="flex-1 min-w-0">
+            <h1 className="text-[40px] sm:text-[56px] font-extrabold lowercase leading-[0.95] tracking-tight text-foreground mb-4">
+              gitlawb node.
+            </h1>
+            <div className="text-[13px] leading-[1.8] text-muted-foreground max-w-[560px] mb-6">
+              <p className="m-0">
+                A federated git node on the <span className="text-warm-text">{node?.network ?? 'gitlawb'}</span>{' '}
+                network. Repos are pushed by agents over signed HTTP, certified per ref update, and
+                gossiped to peer nodes over libp2p.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2.5 max-w-[560px]">
+              <IdentityRow label="node did" value={node ? truncateDid(node.did) : null} copy={node?.did} />
+              <IdentityRow
+                label="p2p id"
+                value={node?.p2p_peer_id ? `${node.p2p_peer_id.slice(0, 10)}…${node.p2p_peer_id.slice(-6)}` : node ? '—' : null}
+                copy={node?.p2p_peer_id ?? undefined}
+              />
+              {node && node.protocols.length > 0 && (
+                <div className="flex items-center gap-2 flex-wrap">
+                  <MicroLabel className="w-[72px] shrink-0">protocols</MicroLabel>
+                  {node.protocols.map(p => (
+                    <span key={p} className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground border border-border-inner rounded-[2px] px-1.5 py-0.5">
+                      {p}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Stat tiles */}
+          <div className="grid grid-cols-2 border border-border shrink-0 w-full sm:w-[420px]">
+            <StatTile
+              label="repositories"
+              to="/repos"
+              value={stats ? stats.repos.toLocaleString() : loading ? null : '—'}
+            />
+            <StatTile
+              label="agents"
+              to="/agents"
+              value={stats ? stats.agents.toLocaleString() : loading ? null : '—'}
+              className="border-l border-border"
+            />
+            <StatTile
+              label="peers"
+              to="/peers"
+              value={peers ? peers.length.toLocaleString() : loading ? null : '—'}
+              note={reachablePeers !== undefined ? `${reachablePeers} reachable` : undefined}
+              className="border-t border-border"
+            />
+            <StatTile
+              label="pushes"
+              to="/events"
+              value={stats ? stats.pushes.toLocaleString() : loading ? null : '—'}
+              className="border-l border-t border-border"
+            />
+          </div>
+        </div>
+      </section>
+
+      {unreachable && (
+        <div className="mt-8 border border-border py-16 text-center">
+          <p className="m-0 text-[13px] text-destructive mb-4">node unreachable — every endpoint failed to answer</p>
+          <Pill onClick={refresh}>retry</Pill>
+        </div>
+      )}
+
+      {/* ── Panels ───────────────────────────────────────────────────────── */}
+      <div className="grid lg:grid-cols-3 gap-6 pt-8 pb-20">
+
+        {/* Recent activity */}
+        <section className="lg:col-span-2 border border-border self-start">
+          <PanelHeader label="recent activity">
+            <Pill to="/events">view all →</Pill>
+          </PanelHeader>
+          <RefUpdateList
+            events={events ? events.slice(0, 8) : loading ? null : []}
+            header={false}
+            skeletonCount={8}
+          />
+        </section>
+
+        <div className="flex flex-col gap-6">
+
+          {/* Agent tasks */}
+          <section className="border border-border">
+            <PanelHeader label="agent tasks">
+              <Pill to="/tasks">view all →</Pill>
+            </PanelHeader>
+            <div className="grid grid-cols-4">
+              {taskCounts.map(({ status, count }, i) => (
+                <div key={status} className={cn('px-3 py-3 text-center', i > 0 && 'border-l border-border-inner')}>
+                  <span aria-hidden="true" className={cn('block text-[8px] mb-1.5', taskStatusColor(status))}>◆</span>
+                  <p className="m-0 text-[16px] font-bold tabular-nums leading-none">
+                    {tasks ? count : '—'}
+                  </p>
+                  <MicroLabel className="block mt-1.5 !text-[9px]">{status}</MicroLabel>
+                </div>
+              ))}
+            </div>
+            {latestTasks.length > 0 && (
+              <ul className="m-0 p-0 list-none border-t border-border-inner">
+                {latestTasks.map(task => (
+                  <li key={task.id} className="border-b border-border-inner last:border-b-0 hover:bg-hover transition-colors">
+                    <Link to={`/tasks/${task.id}`} className="flex items-baseline gap-2.5 px-4 py-2.5 min-w-0">
+                      <span aria-hidden="true" className={cn('text-[8px] shrink-0', taskStatusColor(task.status))}>◆</span>
+                      <span className="text-[12px] text-foreground truncate flex-1">{taskTitle(task)}</span>
+                      <span className="text-[10px] text-dim tabular-nums whitespace-nowrap">{timeAgo(task.created_at)}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {openTasks && (
+              <p className="m-0 px-4 py-2.5 border-t border-border-inner text-[10px] text-dim">
+                {openTasks.length} open of latest {tasks?.length ?? 0}
+              </p>
+            )}
+          </section>
+
+          {/* P2P */}
+          <section className="border border-border">
+            <PanelHeader label="p2p gossip">
+              <Pill to="/network">network →</Pill>
+            </PanelHeader>
+            <div className="px-4 sm:px-5 py-4 flex flex-col gap-2.5">
+              <div className="flex items-center gap-2">
+                <span aria-hidden="true" className={cn('text-[8px]', p2p?.enabled ? 'text-ok' : 'text-status-dot')}>◆</span>
+                <span className="text-[12px] text-muted-foreground">
+                  {p2p ? (p2p.enabled ? 'gossip enabled' : 'gossip disabled') : loading ? 'checking…' : 'unknown'}
+                </span>
+              </div>
+              {p2p?.topics && p2p.topics.length > 0 && (
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  {p2p.topics.map(t => (
+                    <span key={t} className="text-[10px] text-warm-text border border-border-inner rounded-[2px] px-1.5 py-0.5">
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {typeof p2p?.connected_peers === 'number' && (
+                <span className="text-[11px] text-dim tabular-nums">
+                  {p2p.connected_peers} connected · {p2p.gossipsub_mesh_peers ?? 0} in mesh
+                </span>
+              )}
+            </div>
+          </section>
+
+          {/* Quick clone */}
+          <section className="border border-border">
+            <PanelHeader label="quick clone" />
+            {recentRepos === null ? (
+              <div className="px-4 py-3 flex flex-col gap-2">
+                {Array.from({ length: 4 }, (_, i) => <Skeleton key={i} className="h-5 w-full" />)}
+              </div>
+            ) : (
+              <ul className="m-0 p-0 list-none">
+                {recentRepos.map(repo => (
+                  <li key={repo.id} className="flex items-center gap-2 px-4 py-2 border-b border-border-inner last:border-b-0 min-w-0">
+                    <Link
+                      to={`/repos/${encodeURIComponent(repo.owner_did)}/${encodeURIComponent(repo.name)}`}
+                      className="text-[12px] truncate flex-1 text-foreground hover:text-warm-text transition-colors"
+                    >
+                      <span className="text-dim">{shortDid(repo.owner_did)}/</span>
+                      <span className="font-bold">{repo.name}</span>
+                    </Link>
+                    <CopyButton value={repo.clone_url} label="clone" />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/NetworkPage.tsx
+++ b/src/pages/NetworkPage.tsx
@@ -1,0 +1,92 @@
+import { useRefreshKey } from '../hooks/useRefreshKey';
+import { useNetwork } from '../hooks/useNetwork';
+import { FEDERATED_NODES } from '../lib/nodes';
+import { RepoHero } from '../components/repos/RepoHero';
+import { NodeCard, NodeCardSkeleton } from '../components/network/NodeCard';
+import { ReplicationTable } from '../components/network/ReplicationTable';
+import { MicroLabel } from '../components/ui/MicroLabel';
+import { Skeleton } from '../components/ui/Skeleton';
+
+export default function NetworkPage() {
+  const { refreshKey, refresh } = useRefreshKey();
+  const { snapshots, replication, loading } = useNetwork(refreshKey);
+
+  const live = snapshots?.filter(s => s.reachable).length;
+  const clusterRepos = snapshots
+    ? Math.max(0, ...snapshots.map(s => s.stats?.repos ?? 0))
+    : null;
+  const clusterAgents = snapshots
+    ? snapshots.reduce((sum, s) => sum + (s.stats?.agents ?? 0), 0)
+    : null;
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12">
+
+      <RepoHero
+        totalCount={live ?? 0}
+        page={1}
+        perPage={FEDERATED_NODES.length}
+        windowStart={1}
+        windowEnd={FEDERATED_NODES.length}
+        refreshing={loading}
+        onRefresh={refresh}
+        title="network."
+        indexLabel="federation status"
+        countNoun="nodes live"
+        description={
+          <p className="m-0">
+            The gitlawb federation: independent nodes replicating repos to each other. Each push is
+            certified on its origin node, announced on the{' '}
+            <code className="text-warm-text">gitlawb/ref-updates/v1</code> gossip topic, and picked
+            up by every peer. Below, the same feed observed from each node — and how far each one
+            lags.
+          </p>
+        }
+        cells={[
+          {
+            label: 'nodes live',
+            value: live !== undefined ? `${live}/${FEDERATED_NODES.length}` : '—',
+          },
+          { label: 'cluster repos', value: clusterRepos !== null && clusterRepos > 0 ? clusterRepos.toLocaleString() : '—' },
+          { label: 'cluster agents', value: clusterAgents !== null && clusterAgents > 0 ? clusterAgents.toLocaleString() : '—' },
+          {
+            label: 'replication',
+            value: replication ? `${replication.coveragePercent}%` : '—',
+          },
+        ]}
+      />
+
+      <div className="pt-8 pb-20 flex flex-col gap-6">
+
+        {/* Node cards */}
+        <section>
+          <MicroLabel className="block mb-3">nodes</MicroLabel>
+          <div className="grid sm:grid-cols-2 xl:grid-cols-4 gap-4">
+            {snapshots === null
+              ? FEDERATED_NODES.map(n => <NodeCardSkeleton key={n.id} />)
+              : snapshots.map(s => <NodeCard key={s.node.id} snapshot={s} />)}
+          </div>
+        </section>
+
+        {/* Replication */}
+        {replication ? (
+          <ReplicationTable
+            replication={replication}
+            labels={(snapshots ?? [])
+              .filter(s => s.events !== null)
+              .map(s => s.node.label)}
+          />
+        ) : snapshots === null ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <div className="border border-border py-12 text-center">
+            <p className="m-0 text-[13px] text-muted-foreground">
+              replication analysis needs event feeds from at least two nodes
+            </p>
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/src/pages/PeersPage.tsx
+++ b/src/pages/PeersPage.tsx
@@ -2,15 +2,17 @@ import { useSearchParams } from 'react-router-dom';
 import { useCallback, useRef, useState } from 'react';
 import { useListNav } from '../hooks/useShortcuts';
 import { DEFAULT_PER_PAGE, PER_PAGE_OPTIONS } from '../lib/constants';
-import { useAgents } from '../hooks/useAgents';
+import { usePeers } from '../hooks/usePeers';
 import { useRefreshKey } from '../hooks/useRefreshKey';
-import { AgentList } from '../components/agents/AgentList';
+import { PeerList } from '../components/peers/PeerList';
 import { RepoPagination } from '../components/repos/RepoPagination';
 import { RepoHero } from '../components/repos/RepoHero';
 import { MicroLabel } from '../components/ui/MicroLabel';
 import { Pill } from '../components/ui/Pill';
+import { CopyButton } from '../components/ui/CopyButton';
+import { cn } from '../lib/utils';
 
-export default function AgentsPage() {
+export default function PeersPage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const search = searchParams.get('q') ?? '';
@@ -35,30 +37,25 @@ export default function AgentsPage() {
     [setSearchParams],
   );
 
-  const { agents, totalCount, totalPages, windowStart, windowEnd, loading, error } = useAgents({
-    page,
-    perPage,
-    search,
-    refreshKey,
-  });
+  const {
+    peers, p2p, allCount, reachableCount,
+    totalCount, totalPages, windowStart, windowEnd, loading, error,
+  } = usePeers({ page, perPage, search, refreshKey });
 
   const listRef = useRef<HTMLDivElement>(null);
   useListNav(listRef);
 
-  // Local input state — a URL-controlled input drops keystrokes while router
-  // transitions lag; sync from URL only when the input isn't focused.
   const [searchValue, setSearchValue] = useState(search);
   const [prevSearch, setPrevSearch] = useState(search);
   if (prevSearch !== search) {
     setPrevSearch(search);
     const inputFocused =
-      typeof document !== 'undefined' && document.activeElement?.id === 'agent-search';
+      typeof document !== 'undefined' && document.activeElement?.id === 'peer-search';
     if (!inputFocused && search !== searchValue) setSearchValue(search);
   }
 
   return (
     <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12">
-
 
       <RepoHero
         totalCount={totalCount}
@@ -68,53 +65,84 @@ export default function AgentsPage() {
         windowEnd={windowEnd}
         refreshing={loading}
         onRefresh={refresh}
-        title="agents."
-        indexLabel="agent index"
-        countNoun="agents"
-        statLabel="agents"
+        title="peers."
+        indexLabel="peer directory"
+        countNoun="peers"
         description={
           <p className="m-0">
-            Registered identities on this gitlawb node. Every agent is a{' '}
-            <code className="text-warm-text">did:key</code> — inspect capabilities, trust scores,
-            and jump to the repositories each agent owns.
+            Other gitlawb nodes this node has discovered. Peers announce over HTTP, exchange{' '}
+            <code className="text-warm-text">ref-update</code> gossip on libp2p, and replicate
+            repos across the federation. Ping any peer to check it live.
           </p>
         }
+        cells={[
+          { label: 'known peers', value: allCount > 0 ? allCount.toLocaleString() : '—' },
+          { label: 'reachable', value: allCount > 0 ? reachableCount.toLocaleString() : '—' },
+          { label: 'unreachable', value: allCount > 0 ? (allCount - reachableCount).toLocaleString() : '—' },
+          {
+            label: 'gossip mesh',
+            value: p2p?.enabled
+              ? String(p2p.connected_peers ?? p2p.gossipsub_all_peers ?? 0)
+              : p2p ? 'off' : '—',
+          },
+        ]}
       />
 
       <div className="pt-8 pb-20">
 
+        {/* P2P identity strip */}
+        {p2p?.enabled && p2p.peer_id && (
+          <div className="flex items-center gap-x-4 gap-y-2 flex-wrap border border-border px-4 sm:px-6 py-3 mb-6">
+            <span className="flex items-center gap-2">
+              <span aria-hidden="true" className="text-[8px] text-ok">◆</span>
+              <MicroLabel>libp2p</MicroLabel>
+            </span>
+            <span className="text-[12px] text-muted-foreground truncate" title={p2p.peer_id}>
+              {p2p.peer_id.slice(0, 12)}…{p2p.peer_id.slice(-8)}
+            </span>
+            <CopyButton value={p2p.peer_id} label="peer id" />
+            {(p2p.topics ?? []).map(t => (
+              <span key={t} className="text-[10px] text-warm-text border border-border-inner rounded-[2px] px-1.5 py-0.5">
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+
         {/* Search */}
         <div className="max-w-[560px] mb-4">
           <MicroLabel className="block mb-1.5">
-            <label htmlFor="agent-search">search</label>
+            <label htmlFor="peer-search">search</label>
           </MicroLabel>
           <input
-            id="agent-search"
+            id="peer-search"
             type="search"
             value={searchValue}
             onChange={e => {
               setSearchValue(e.target.value);
               setParams({ q: e.target.value, page: null }, true);
             }}
-            placeholder="search by did or capability…"
+            placeholder="search by did or host…"
             autoComplete="off"
             spellCheck={false}
-            className="w-full h-9 px-3 text-[13px] bg-transparent border border-border rounded-[2px]
-              text-foreground placeholder:text-dim
-              focus:outline-none focus-visible:ring-1 focus-visible:ring-warm focus:border-dim
-              transition-colors"
+            className={cn(
+              'w-full h-9 px-3 text-[13px] bg-transparent border border-border rounded-[2px]',
+              'text-foreground placeholder:text-dim',
+              'focus:outline-none focus-visible:ring-1 focus-visible:ring-warm focus:border-dim',
+              'transition-colors',
+            )}
           />
         </div>
 
         {error ? (
           <div className="border border-border py-16 text-center">
-            <p className="m-0 text-[13px] text-destructive mb-4">failed to load agents: {error}</p>
+            <p className="m-0 text-[13px] text-destructive mb-4">failed to load peers: {error}</p>
             <Pill onClick={refresh}>retry</Pill>
           </div>
         ) : (
           <>
             <div ref={listRef}>
-              <AgentList agents={agents} loading={loading} skeletonCount={Math.min(perPage, 12)} />
+              <PeerList peers={peers} loading={loading} skeletonCount={Math.min(perPage, 12)} />
             </div>
             <RepoPagination
               page={page}
@@ -125,7 +153,7 @@ export default function AgentsPage() {
               windowEnd={windowEnd}
               onPageChange={p => setParams({ page: p <= 1 ? null : String(p) })}
               onPerPageChange={n => setParams({ per: n === DEFAULT_PER_PAGE ? null : String(n), page: null })}
-              noun="agents"
+              noun="peers"
             />
           </>
         )}

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -10,7 +10,6 @@ import { RepoPagination } from '../components/repos/RepoPagination';
 import { RepoHero } from '../components/repos/RepoHero';
 import { RepoToolbar } from '../components/repos/RepoToolbar';
 import type { ForkFilter } from '../components/repos/RepoToolbar';
-import { ExploreTabs } from '../components/layout/ExploreTabs';
 import { Pill } from '../components/ui/Pill';
 
 const SORTS: RepoSort[] = ['updated', 'created', 'oldest', 'name', 'stars'];
@@ -60,7 +59,6 @@ export default function RepositoriesPage() {
   return (
     <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12">
 
-      <ExploreTabs />
 
       <RepoHero
         totalCount={totalCount}

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -1,0 +1,208 @@
+import { useState, useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { cn } from '../lib/utils';
+import { fetchTask, taskTitle, prettyJson, truncateDid, formatDate, timeAgo, didKeySegment } from '../lib/api';
+import type { ApiTask } from '../lib/api';
+import { taskStatusColor } from '../components/tasks/status';
+import { MicroLabel } from '../components/ui/MicroLabel';
+import { Pill } from '../components/ui/Pill';
+import { CopyButton } from '../components/ui/CopyButton';
+import { Skeleton } from '../components/ui/Skeleton';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '../components/ui/breadcrumb';
+
+function PageBreadcrumb({ id }: { id: string }) {
+  return (
+    <Breadcrumb className="mb-8 sm:mb-10">
+      <BreadcrumbList className="text-[12.5px] gap-1.5 sm:gap-2 flex-nowrap min-w-0">
+        <BreadcrumbItem className="shrink-0">
+          <BreadcrumbLink asChild>
+            <Link
+              to="/tasks"
+              className="text-muted-foreground hover:text-foreground transition-colors duration-150
+                focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-warm"
+            >
+              tasks
+            </Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator className="text-dim shrink-0" />
+        <BreadcrumbItem className="min-w-0">
+          <BreadcrumbPage className="text-foreground font-bold truncate block">
+            {id.slice(0, 8)}
+          </BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5 min-w-0">
+      <MicroLabel>{label}</MicroLabel>
+      <div className="text-[13px] text-foreground min-w-0">{children}</div>
+    </div>
+  );
+}
+
+function DidField({ label, did }: { label: string; did: string }) {
+  return (
+    <Field label={label}>
+      <span className="flex items-center gap-2 min-w-0">
+        <Link
+          to={`/agents?q=${encodeURIComponent(didKeySegment(did))}`}
+          className="truncate hover:text-warm-text transition-colors"
+          title={did}
+        >
+          {truncateDid(did)}
+        </Link>
+        <CopyButton value={did} label="did" />
+      </span>
+    </Field>
+  );
+}
+
+function JsonPanel({ label, raw }: { label: string; raw: string }) {
+  return (
+    <section className="border border-border min-w-0">
+      <div className="flex items-center justify-between gap-3 px-4 sm:px-6 h-10 border-b border-border bg-surface">
+        <MicroLabel>{label}</MicroLabel>
+        <CopyButton value={raw} label={label} />
+      </div>
+      <pre className="m-0 px-4 sm:px-6 py-4 text-[12px] leading-[1.7] text-muted-foreground overflow-x-auto whitespace-pre-wrap break-words">
+        {prettyJson(raw)}
+      </pre>
+    </section>
+  );
+}
+
+export default function TaskDetailPage() {
+  const { id = '' } = useParams();
+  const [task, setTask] = useState<ApiTask | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Render-phase reset on navigation between tasks (react-hooks/set-state-in-effect)
+  const [prevId, setPrevId] = useState(id);
+  if (prevId !== id) {
+    setPrevId(id);
+    setTask(null);
+    setError(null);
+  }
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchTask(id, controller.signal)
+      .then(t => {
+        if (!controller.signal.aborted) setTask(t);
+      })
+      .catch(err => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error && err.message === 'not_found' ? 'not_found' : 'failed');
+        }
+      });
+    return () => controller.abort();
+  }, [id]);
+
+  if (error) {
+    return (
+      <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12 py-8 sm:py-12">
+        <PageBreadcrumb id={id} />
+        <div className="flex flex-col items-center justify-center py-24 sm:py-32 text-center border border-border">
+          <span className="text-[56px] mb-8 opacity-10 select-none" aria-hidden="true">◆</span>
+          <h1 className="m-0 mb-3 text-[20px] font-bold lowercase">
+            {error === 'not_found' ? 'task not found' : 'failed to load task'}
+          </h1>
+          <p className="m-0 mb-6 text-[13px] text-muted-foreground">
+            {error === 'not_found'
+              ? `no task with id ${id} exists on this node`
+              : 'the node did not answer — try again'}
+          </p>
+          <Pill to="/tasks">← back to tasks</Pill>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12 py-8 sm:py-12">
+      <PageBreadcrumb id={id} />
+
+      {/* Header */}
+      <section className="border border-border grid-lines mb-6">
+        <div className="flex items-center justify-between gap-3 px-4 sm:px-6 h-12 border-b border-border">
+          <MicroLabel>agent task</MicroLabel>
+          {task && (
+            <span className={cn('text-[11px] flex items-center gap-1.5', taskStatusColor(task.status))}>
+              <span aria-hidden="true" className="text-[8px]">◆</span>
+              {task.status}
+            </span>
+          )}
+        </div>
+        <div className="px-4 sm:px-6 py-6 sm:py-8">
+          {task === null ? (
+            <>
+              <Skeleton className="h-8 w-2/3 max-w-[480px] mb-4" />
+              <Skeleton className="h-4 w-40" />
+            </>
+          ) : (
+            <>
+              <h1 className="m-0 text-[24px] sm:text-[32px] font-extrabold leading-tight tracking-tight text-foreground mb-3 break-words">
+                {taskTitle(task)}
+              </h1>
+              <div className="flex items-center gap-2 flex-wrap text-[12px] text-muted-foreground">
+                <Pill>{task.kind}</Pill>
+                {task.capability && <Pill>{task.capability}</Pill>}
+                <span className="text-dim">id {task.id}</span>
+                <CopyButton value={task.id} label="id" />
+              </div>
+            </>
+          )}
+        </div>
+      </section>
+
+      {task && (
+        <>
+          {/* Facts grid */}
+          <section className="border border-border mb-6">
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-6 px-4 sm:px-6 py-6">
+              <DidField label="delegator" did={task.delegator_did} />
+              {task.assignee_did ? (
+                <DidField label="assignee" did={task.assignee_did} />
+              ) : (
+                <Field label="assignee"><span className="text-dim">unclaimed</span></Field>
+              )}
+              <Field label="created">
+                <span title={task.created_at}>{formatDate(task.created_at)} · {timeAgo(task.created_at)}</span>
+              </Field>
+              <Field label="updated">
+                <span title={task.updated_at}>{formatDate(task.updated_at)} · {timeAgo(task.updated_at)}</span>
+              </Field>
+              <Field label="deadline">
+                {task.deadline ? <span title={task.deadline}>{formatDate(task.deadline)}</span> : <span className="text-dim">none</span>}
+              </Field>
+              <Field label="repo">
+                {task.repo_id ? <span className="break-all">{task.repo_id}</span> : <span className="text-dim">—</span>}
+              </Field>
+            </div>
+          </section>
+
+          {/* Payload / result */}
+          <div className="flex flex-col gap-6 pb-20">
+            {task.payload && <JsonPanel label="payload" raw={task.payload} />}
+            {task.result && <JsonPanel label="result" raw={task.result} />}
+            {!task.payload && !task.result && (
+              <p className="m-0 text-[13px] text-dim">this task carries no payload or result data</p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,0 +1,177 @@
+import { useSearchParams } from 'react-router-dom';
+import { useCallback, useRef, useState } from 'react';
+import { useListNav } from '../hooks/useShortcuts';
+import { DEFAULT_PER_PAGE, PER_PAGE_OPTIONS } from '../lib/constants';
+import { useTasks } from '../hooks/useTasks';
+import { useRefreshKey } from '../hooks/useRefreshKey';
+import type { TaskStatus } from '../lib/api';
+import { TaskList } from '../components/tasks/TaskList';
+import { TASK_STATUSES, taskStatusColor } from '../components/tasks/status';
+import { RepoPagination } from '../components/repos/RepoPagination';
+import { RepoHero } from '../components/repos/RepoHero';
+import { MicroLabel } from '../components/ui/MicroLabel';
+import { Pill } from '../components/ui/Pill';
+import { cn } from '../lib/utils';
+
+export default function TasksPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const search = searchParams.get('q') ?? '';
+  const rawStatus = searchParams.get('status') as TaskStatus | null;
+  const status: TaskStatus | undefined =
+    rawStatus && TASK_STATUSES.includes(rawStatus) ? rawStatus : undefined;
+  const rawPage = Number(searchParams.get('page'));
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+  const rawPer = Number(searchParams.get('per'));
+  const perPage = PER_PAGE_OPTIONS.includes(rawPer) ? rawPer : DEFAULT_PER_PAGE;
+
+  const { refreshKey, refresh } = useRefreshKey();
+
+  const setParams = useCallback(
+    (updates: Record<string, string | null>, replace = false) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev);
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null || value === '') next.delete(key);
+          else next.set(key, value);
+        }
+        return next;
+      }, { replace });
+    },
+    [setSearchParams],
+  );
+
+  const { tasks, allCount, totalCount, totalPages, windowStart, windowEnd, loading, error } =
+    useTasks({ page, perPage, status, search, refreshKey });
+
+  const listRef = useRef<HTMLDivElement>(null);
+  useListNav(listRef);
+
+  const [searchValue, setSearchValue] = useState(search);
+  const [prevSearch, setPrevSearch] = useState(search);
+  if (prevSearch !== search) {
+    setPrevSearch(search);
+    const inputFocused =
+      typeof document !== 'undefined' && document.activeElement?.id === 'task-search';
+    if (!inputFocused && search !== searchValue) setSearchValue(search);
+  }
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4 sm:px-8 lg:px-12">
+
+      <RepoHero
+        totalCount={totalCount}
+        page={page}
+        perPage={perPage}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        refreshing={loading}
+        onRefresh={refresh}
+        title="tasks."
+        indexLabel="agent task queue"
+        countNoun="tasks"
+        statLabel={status ? `${status} tasks` : 'tasks'}
+        description={
+          <p className="m-0">
+            Work delegated between agents on this node. A delegator posts a task with a required{' '}
+            <code className="text-warm-text">capability</code>, an agent claims it, executes, and
+            reports back. The queue refreshes itself every 30s.
+          </p>
+        }
+        cells={[
+          { label: status ? `${status} tasks` : 'latest tasks', value: allCount > 0 ? allCount.toLocaleString() : '—' },
+          { label: 'matching', value: allCount > 0 ? totalCount.toLocaleString() : '—' },
+          { label: 'page', value: String(page) },
+          {
+            label: 'window',
+            value: totalCount > 0 ? `${windowStart.toLocaleString()}–${windowEnd.toLocaleString()}` : '—',
+          },
+        ]}
+      />
+
+      <div className="pt-8 pb-20">
+
+        {/* Toolbar: search + status chips */}
+        <div className="flex flex-wrap items-end gap-x-6 gap-y-4 mb-4">
+          <div className="flex-1 min-w-[240px] max-w-[560px]">
+            <MicroLabel className="block mb-1.5">
+              <label htmlFor="task-search">search</label>
+            </MicroLabel>
+            <input
+              id="task-search"
+              type="search"
+              value={searchValue}
+              onChange={e => {
+                setSearchValue(e.target.value);
+                setParams({ q: e.target.value, page: null }, true);
+              }}
+              placeholder="search by title, kind, capability, or did…"
+              autoComplete="off"
+              spellCheck={false}
+              className={cn(
+                'w-full h-9 px-3 text-[13px] bg-transparent border border-border rounded-[2px]',
+                'text-foreground placeholder:text-dim',
+                'focus:outline-none focus-visible:ring-1 focus-visible:ring-warm focus:border-dim',
+                'transition-colors',
+              )}
+            />
+          </div>
+
+          <div>
+            <MicroLabel className="block mb-1.5">status</MicroLabel>
+            <div className="flex gap-1.5 flex-wrap">
+              <Pill
+                active={!status}
+                onClick={() => setParams({ status: null, page: null })}
+                aria-pressed={!status}
+              >
+                all
+              </Pill>
+              {TASK_STATUSES.map(s => (
+                <Pill
+                  key={s}
+                  active={status === s}
+                  onClick={() => setParams({ status: status === s ? null : s, page: null })}
+                  aria-pressed={status === s}
+                >
+                  <span aria-hidden="true" className={cn('text-[8px]', taskStatusColor(s))}>◆</span>
+                  {s}
+                </Pill>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="border border-border py-16 text-center">
+            <p className="m-0 text-[13px] text-destructive mb-4">failed to load tasks: {error}</p>
+            <Pill onClick={refresh}>retry</Pill>
+          </div>
+        ) : (
+          <>
+            <div ref={listRef}>
+              <TaskList
+                tasks={tasks}
+                loading={loading}
+                skeletonCount={Math.min(perPage, 12)}
+                emptyMessage={search || status ? 'no tasks match' : 'no tasks delegated yet'}
+              />
+            </div>
+            <RepoPagination
+              page={page}
+              totalPages={totalPages}
+              perPage={perPage}
+              totalCount={totalCount}
+              windowStart={windowStart}
+              windowEnd={windowEnd}
+              onPageChange={p => setParams({ page: p <= 1 ? null : String(p) })}
+              onPerPageChange={n => setParams({ per: n === DEFAULT_PER_PAGE ? null : String(n), page: null })}
+              noun="tasks"
+            />
+          </>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,12 @@
   "rewrites": [
     { "source": "/api/:path*", "destination": "https://node.gitlawb.com/api/:path*" },
     { "source": "/node-info", "destination": "https://node.gitlawb.com/" },
+    { "source": "/nodes/node2/node-info", "destination": "https://node2.gitlawb.com/" },
+    { "source": "/nodes/node2/api/:path*", "destination": "https://node2.gitlawb.com/api/:path*" },
+    { "source": "/nodes/node3/node-info", "destination": "https://node3.gitlawb.com/" },
+    { "source": "/nodes/node3/api/:path*", "destination": "https://node3.gitlawb.com/api/:path*" },
+    { "source": "/nodes/manila/node-info", "destination": "https://manila.gitlawb.com/" },
+    { "source": "/nodes/manila/api/:path*", "destination": "https://manila.gitlawb.com/api/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,27 @@ export default defineConfig({
         secure: true,
         rewrite: () => '/',
       },
+      // Peer nodes for the network page (no CORS on nodes — same list as
+      // vercel.json and src/lib/nodes.ts). `/nodes/<id>/node-info` maps to the
+      // peer's root; everything else keeps its path with the prefix stripped.
+      ...Object.fromEntries(
+        [
+          ['node2', 'https://node2.gitlawb.com'],
+          ['node3', 'https://node3.gitlawb.com'],
+          ['manila', 'https://manila.gitlawb.com'],
+        ].map(([id, target]) => [
+          `/nodes/${id}`,
+          {
+            target,
+            changeOrigin: true,
+            secure: true,
+            rewrite: (path: string) => {
+              const rest = path.slice(`/nodes/${id}`.length)
+              return rest === '/node-info' ? '/' : rest
+            },
+          },
+        ]),
+      ),
     },
   },
 })


### PR DESCRIPTION
# Description

Expands the explorer from repos+agents into a full replacement for gitlawb.com/node, with URL paths matching the old site 1:1 (minus the /node prefix) so a single redirect covers the migration:

- / — node overview dashboard: identity, stat tiles, live activity feed, agent-task summary, p2p status, quick clone
- /peers — searchable peer directory with live per-peer ping checks
- /events — node-level ref-update feed with local/gossip filter and visibility-aware 30s auto-refresh
- /tasks + /tasks/:id — agent task queue with server-side status filter, payload-derived titles, and pretty-printed payload/result
- /network — fan-out to the 4 federation nodes with per-node cards and a replication-coverage table over their event feeds

Peer nodes serve no CORS headers, so node2/node3/manila get proxy prefixes in vercel.json and the vite dev proxy. Section nav moves from per-page tabs into the global layout.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / code quality (no behavior change)
- [ ] Documentation
- [ ] Tests / CI

## How was this tested?
Manually tested

## Screenshots
<img width="1232" height="707" alt="Screenshot 2026-07-05 at 10 29 02 PM" src="https://github.com/user-attachments/assets/9135ecbf-e269-4ace-bb69-ca02c12524a7" />

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes (includes typecheck)
- [x] New logic in `src/lib/` has colocated unit tests
- [x] I kept the change focused on a single concern
